### PR TITLE
新增 Webhook 报错通知

### DIFF
--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -754,6 +754,7 @@ body.mobile-nav-open { overflow: hidden; }
   <div class="nav-item"><a class="nav-link" data-tab="tab-other"><i class="bi bi-sliders"></i> 其他配置</a></div>
   <div class="nav-item"><a class="nav-link" data-tab="tab-account"><i class="bi bi-person-gear"></i> 账号密码</a></div>
   <div class="nav-item"><a class="nav-link" data-tab="tab-email"><i class="bi bi-envelope-at"></i> 报错邮箱</a></div>
+  <div class="nav-item"><a class="nav-link" data-tab="tab-webhook"><i class="bi bi-broadcast-pin"></i> Webhook 通知</a></div>
   <div class="nav-divider"></div>
   <div class="nav-item"><a class="nav-link" data-tab="tab-backup"><i class="bi bi-shield-check"></i> 数据备份</a></div>
 </nav>
@@ -2170,6 +2171,61 @@ body.mobile-nav-open { overflow: hidden; }
       <div id="email-msg" style="display:none;font-size:13px;margin-bottom:12px;padding:8px 12px;border-radius:6px;"></div>
       <button type="button" id="btn-save-email" class="btn btn-save" style="font-size:13.5px;padding:8px 24px;border-radius:6px;border:none;cursor:pointer;"><i class="bi bi-save"></i> 保存邮箱配置</button>
       <div class="cfg-hint" style="margin-top:10px;">配置保存在 <code>email.txt</code> 中，保存后立即生效。</div>
+    </div>
+  </div>
+
+
+
+  <!-- ===== Tab: Webhook ===== -->
+  <div class="config-panel" id="tab-webhook">
+    <div class="cfg-card">
+      <div class="cfg-card-header"><i class="bi bi-broadcast-pin"></i><h5>Webhook 通知配置</h5><span class="desc">机器人出错时通过 HTTP Webhook 发送告警</span></div>
+      <div style="display:flex;gap:10px;align-items:flex-start;background:#EFF6FF;border:1px solid #BFDBFE;border-radius:6px;padding:12px 14px;margin-bottom:20px;">
+        <i class="bi bi-info-circle-fill" style="color:#2563EB;font-size:16px;flex-shrink:0;margin-top:1px;"></i>
+        <div style="font-size:12.5px;color:#1E3A8A;line-height:1.7;">
+          支持飞书、钉钉、企业微信、Discord 等通用 HTTP Webhook。请求头和请求体中可使用 <code>$title</code>、<code>$content</code> 占位符。
+        </div>
+      </div>
+      <div class="switch-row">
+        <input class="form-check-input" type="checkbox" id="webhook-enabled">
+        <label class="form-check-label" for="webhook-enabled">启用 Webhook 通知</label>
+        <span class="switch-desc">关闭时不会发送 Webhook</span>
+      </div>
+      <div class="mb-3">
+        <label class="cfg-label" for="webhook-url">Webhook URL</label>
+        <input type="url" class="form-control" id="webhook-url" placeholder="https://example.com/webhook">
+      </div>
+      <div class="row">
+        <div class="col-4 mb-3">
+          <label class="cfg-label" for="webhook-method">Method</label>
+          <select class="form-control" id="webhook-method">
+            <option value="POST">POST</option>
+            <option value="PUT">PUT</option>
+            <option value="PATCH">PATCH</option>
+          </select>
+        </div>
+        <div class="col-5 mb-3">
+          <label class="cfg-label" for="webhook-content-type">Content-Type</label>
+          <input type="text" class="form-control" id="webhook-content-type" placeholder="application/json">
+        </div>
+        <div class="col-3 mb-3">
+          <label class="cfg-label" for="webhook-timeout">超时（秒）</label>
+          <input type="number" class="form-control" id="webhook-timeout" min="1" max="60" placeholder="5">
+        </div>
+      </div>
+      <div class="mb-3">
+        <label class="cfg-label" for="webhook-headers">Headers（JSON，可选）</label>
+        <textarea class="form-control" id="webhook-headers" rows="4" placeholder='{"Authorization":"Bearer token"}'></textarea>
+      </div>
+      <div class="mb-4">
+        <label class="cfg-label" for="webhook-body">Body</label>
+        <textarea class="form-control" id="webhook-body" rows="7" placeholder='{"title":"$title","content":"$content"}'></textarea>
+        <div class="cfg-hint">JSON 类型会按 JSON 发送；其他 Content-Type 会按原始文本发送。</div>
+      </div>
+      <div id="webhook-msg" style="display:none;font-size:13px;margin-bottom:12px;padding:8px 12px;border-radius:6px;"></div>
+      <button type="button" id="btn-save-webhook" class="btn btn-save" style="font-size:13.5px;padding:8px 24px;border-radius:6px;border:none;cursor:pointer;"><i class="bi bi-save"></i> 保存 Webhook 配置</button>
+      <button type="button" id="btn-test-webhook" class="btn btn-load" style="font-size:13.5px;padding:8px 24px;border-radius:6px;border:none;cursor:pointer;margin-left:8px;"><i class="bi bi-send"></i> 发送测试</button>
+      <div class="cfg-hint" style="margin-top:10px;">配置保存在 <code>webhook.json</code> 中，保存后立即生效。</div>
     </div>
   </div>
 
@@ -4440,6 +4496,62 @@ $(function(){
       data: JSON.stringify(d),
       success: function(res){ showMsg('email-msg', res.message, res.status==='success'); },
       error: function(xhr){ showMsg('email-msg','请求失败: '+xhr.responseText, false); }
+    });
+  });
+
+
+
+  // ===== Webhook Panel =====
+  function collectWebhookConfig(){
+    var headers = {};
+    var headerText = $('#webhook-headers').val().trim();
+    if(headerText){
+      try { headers = JSON.parse(headerText); }
+      catch(e){ showMsg('webhook-msg','Headers 不是合法 JSON: '+e.message,false); return null; }
+    }
+    return {
+      enabled: $('#webhook-enabled').is(':checked'),
+      url: $('#webhook-url').val().trim(),
+      method: $('#webhook-method').val(),
+      content_type: $('#webhook-content-type').val().trim() || 'application/json',
+      headers: headers,
+      body: $('#webhook-body').val(),
+      timeout: parseInt($('#webhook-timeout').val() || '5', 10)
+    };
+  }
+  function loadWebhookConfig(){
+    $.getJSON('/get_webhook_config', function(res){
+      if(res.status === 'success'){
+        $('#webhook-enabled').prop('checked', !!res.enabled);
+        $('#webhook-url').val(res.url || '');
+        $('#webhook-method').val(res.method || 'POST');
+        $('#webhook-content-type').val(res.content_type || 'application/json');
+        $('#webhook-timeout').val(res.timeout || 5);
+        $('#webhook-headers').val(JSON.stringify(res.headers || {}, null, 2));
+        $('#webhook-body').val(res.body || '{"title":"$title","content":"$content"}');
+      } else {
+        showMsg('webhook-msg', res.message || '加载 Webhook 配置失败', false);
+      }
+    });
+  }
+  $(document).on('click', '[data-tab="tab-webhook"]', loadWebhookConfig);
+  $('#btn-save-webhook').click(function(){
+    var d = collectWebhookConfig(); if(!d) return;
+    if(d.enabled && !d.url){ showMsg('webhook-msg','启用 Webhook 时 URL 不能为空',false); return; }
+    $.ajax({ url:'/save_webhook_config', type:'POST', contentType:'application/json',
+      data: JSON.stringify(d),
+      success: function(res){ showMsg('webhook-msg', res.message, res.status==='success'); },
+      error: function(xhr){ showMsg('webhook-msg','请求失败: '+xhr.responseText, false); }
+    });
+  });
+  $('#btn-test-webhook').click(function(){
+    var d = collectWebhookConfig(); if(!d) return;
+    d.enabled = true;
+    if(!d.url){ showMsg('webhook-msg','测试 Webhook 时 URL 不能为空',false); return; }
+    $.ajax({ url:'/test_webhook', type:'POST', contentType:'application/json',
+      data: JSON.stringify(d),
+      success: function(res){ showMsg('webhook-msg', res.message, res.status==='success'); },
+      error: function(xhr){ showMsg('webhook-msg','请求失败: '+xhr.responseText, false); }
     });
   });
 

--- a/tests/test_webhook_send.py
+++ b/tests/test_webhook_send.py
@@ -1,0 +1,129 @@
+import os
+import tempfile
+import unittest
+from unittest.mock import Mock, patch
+
+import webhook_send
+
+
+class WebhookSendTests(unittest.TestCase):
+    def test_default_config_is_disabled_and_has_safe_defaults(self):
+        cfg = webhook_send.default_config()
+        self.assertFalse(cfg["enabled"])
+        self.assertEqual(cfg["method"], "POST")
+        self.assertEqual(cfg["content_type"], "application/json")
+        self.assertIn("$title", cfg["body"])
+        self.assertIn("$content", cfg["body"])
+        self.assertIn("msg_type", cfg["body"])
+
+    def test_load_config_returns_defaults_when_file_missing(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            cfg = webhook_send.load_config(os.path.join(tmp, "webhook.json"))
+            self.assertFalse(cfg["enabled"])
+
+    def test_save_and_load_config_merges_with_defaults(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = os.path.join(tmp, "webhook.json")
+            webhook_send.save_config({"enabled": True, "url": "https://example.com/hook"}, path)
+            cfg = webhook_send.load_config(path)
+            self.assertTrue(cfg["enabled"])
+            self.assertEqual(cfg["url"], "https://example.com/hook")
+            self.assertEqual(cfg["method"], "POST")
+
+    def test_save_config_rejects_invalid_json_body_template(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = os.path.join(tmp, "webhook.json")
+            with self.assertRaises(ValueError):
+                webhook_send.save_config({
+                    "enabled": True,
+                    "url": "https://example.com/hook",
+                    "content_type": "application/json",
+                    "body": '{"msg":"unterminated}',
+                }, path)
+            self.assertFalse(os.path.exists(path))
+
+    @patch("webhook_send.requests.request")
+    def test_send_webhook_posts_rendered_json_body_and_headers(self, request_mock):
+        response = Mock(status_code=200, text="ok")
+        request_mock.return_value = response
+        cfg = {
+            "enabled": True,
+            "url": "https://example.com/hook",
+            "method": "POST",
+            "content_type": "application/json",
+            "headers": {"X-Test": "hello $title"},
+            "body": '{"msg":"$title: $content"}',
+            "timeout": 3,
+        }
+        ok, message = webhook_send.send_webhook("title", "content", cfg)
+        self.assertTrue(ok, message)
+        request_mock.assert_called_once()
+        self.assertEqual(request_mock.call_args.args[0], "POST")
+        self.assertEqual(request_mock.call_args.args[1], "https://example.com/hook")
+        kwargs = request_mock.call_args.kwargs
+        self.assertEqual(kwargs["headers"]["X-Test"], "hello title")
+        self.assertEqual(kwargs["headers"]["Content-Type"], "application/json")
+        self.assertEqual(kwargs["json"], {"msg": "title: content"})
+        self.assertEqual(kwargs["timeout"], 3)
+
+    @patch("webhook_send.requests.request")
+    def test_send_webhook_uses_text_data_for_non_json_content_type(self, request_mock):
+        request_mock.return_value = Mock(status_code=204, text="")
+        cfg = {"enabled": True, "url": "https://example.com/hook", "content_type": "text/plain", "body": "$title\n$content"}
+        ok, message = webhook_send.send_webhook("t", "c", cfg)
+        self.assertTrue(ok, message)
+        kwargs = request_mock.call_args.kwargs
+        self.assertEqual(kwargs["data"], "t\nc")
+        self.assertNotIn("json", kwargs)
+
+    def test_send_webhook_is_noop_when_disabled_or_url_missing(self):
+        ok, message = webhook_send.send_webhook("t", "c", {"enabled": False})
+        self.assertTrue(ok)
+        self.assertIn("disabled", message.lower())
+        ok, message = webhook_send.send_webhook("t", "c", {"enabled": True, "url": ""})
+        self.assertFalse(ok)
+        self.assertIn("url", message.lower())
+
+    @patch("webhook_send.requests.request", side_effect=RuntimeError("network down"))
+    def test_send_webhook_catches_request_errors(self, request_mock):
+        ok, message = webhook_send.send_webhook("t", "c", {"enabled": True, "url": "https://example.com", "body": '{"title":"$title","content":"$content"}'})
+        self.assertFalse(ok)
+        self.assertIn("network down", message)
+
+    @patch("webhook_send.requests.request")
+    def test_send_webhook_reports_feishu_business_error_even_with_http_200(self, request_mock):
+        response = Mock(status_code=200, text='{"code":19024,"msg":"Key Words Not Found"}')
+        response.json.side_effect = ValueError("no json")
+        request_mock.return_value = response
+        cfg = {
+            "enabled": True,
+            "url": "https://open.feishu.cn/open-apis/bot/v2/hook/example",
+            "body": '{"title":"$title","content":"$content"}',
+        }
+
+        ok, message = webhook_send.send_webhook("t", "c", cfg)
+
+        self.assertFalse(ok)
+        self.assertIn("19024", message)
+        self.assertIn("Key Words Not Found", message)
+
+    @patch("webhook_send.requests.request")
+    def test_send_webhook_json_escapes_multiline_content_before_parsing(self, request_mock):
+        request_mock.return_value = Mock(status_code=200, text='{"code":0,"msg":"ok"}')
+        cfg = {
+            "enabled": True,
+            "url": "https://example.com/hook",
+            "content_type": "application/json",
+            "body": '{"msg_type":"text","content":{"text":"$title\\n\\n$content"}}',
+        }
+        content = '错误信息：\nTraceback (most recent call last):\n  File "wxbot_core.py", line 1\nerr信息：\nFind Control Timeout'
+
+        ok, message = webhook_send.send_webhook("机器人告警", content, cfg)
+
+        self.assertTrue(ok, message)
+        sent_json = request_mock.call_args.kwargs["json"]
+        self.assertEqual(sent_json["content"]["text"], "机器人告警\n\n" + content)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/web_server.py
+++ b/web_server.py
@@ -25,6 +25,7 @@ import webbrowser
 import time
 import socket
 import email_send
+import webhook_send
 import ctypes
 import atexit
 import importlib.util
@@ -63,6 +64,7 @@ PORT = 10001
 CONFIG_FILE = os.path.join(base_dir(), 'config', 'config.json')
 ADMIN_FILE  = os.path.join(base_dir(), 'config', 'admin.json')
 EMAIL_FILE  = os.path.join(base_dir(), 'config', 'email.txt')
+WEBHOOK_FILE = os.path.join(base_dir(), 'config', 'webhook.json')
 PROMPT_DIR  = os.path.join(base_dir(), 'config', 'prompt')
 BACKUP_BASE = os.path.join(base_dir(), 'old_wxbot_config')
 APP_SECRET_FILE = os.path.join(base_dir(), 'config', 'panel_secret.key')
@@ -1338,6 +1340,39 @@ def save_email_config():
 import threading
 
 _tk_lock = threading.Lock()  # 确保同一时刻只弹一个文件选择框
+
+
+@app.route('/get_webhook_config')
+@login_required
+def get_webhook_config():
+    try:
+        config = webhook_send.load_config(WEBHOOK_FILE)
+        return jsonify({'status': 'success', **config})
+    except Exception as e:
+        return jsonify({'status': 'error', 'message': str(e)})
+
+@app.route('/save_webhook_config', methods=['POST'])
+@login_required
+def save_webhook_config():
+    try:
+        data = request.get_json() or {}
+        config = webhook_send.save_config(data, WEBHOOK_FILE)
+        log('SUCCESS', f"Webhook 配置已更新，启用状态: {config.get('enabled')}")
+        return jsonify({'status': 'success', 'message': 'Webhook 配置已保存', 'config': config})
+    except Exception as e:
+        log('ERROR', f'保存 Webhook 配置失败: {e}')
+        return jsonify({'status': 'error', 'message': str(e)})
+
+@app.route('/test_webhook', methods=['POST'])
+@login_required
+def test_webhook():
+    try:
+        data = request.get_json() or {}
+        ok, message = webhook_send.send_webhook('SiverWXbot_plus 测试通知', '这是一条 Webhook 测试消息。', data)
+        return jsonify({'status': 'success' if ok else 'error', 'message': message})
+    except Exception as e:
+        log('ERROR', f'测试 Webhook 失败: {e}')
+        return jsonify({'status': 'error', 'message': str(e)})
 
 @app.route('/pick_image_file', methods=['GET'])
 @login_required

--- a/webhook_send.py
+++ b/webhook_send.py
@@ -1,0 +1,132 @@
+"""Generic webhook notification support for SiverWXbot_plus."""
+
+from __future__ import annotations
+
+import json
+import os
+from copy import deepcopy
+from typing import Any, Dict, Optional, Tuple
+
+import requests
+
+CONFIG_PATH = os.path.join(os.path.dirname(os.path.abspath(__file__)), "config", "webhook.json")
+
+
+def default_config() -> Dict[str, Any]:
+    return {
+        "enabled": False,
+        "url": "",
+        "method": "POST",
+        "content_type": "application/json",
+        "headers": {},
+        "body": '{"msg_type":"text","content":{"text":"$title\\n\\n$content"}}',
+        "timeout": 5,
+    }
+
+
+def _merge_with_defaults(config: Optional[Dict[str, Any]]) -> Dict[str, Any]:
+    merged = default_config()
+    if isinstance(config, dict):
+        merged.update(config)
+    merged["enabled"] = bool(merged.get("enabled", False))
+    merged["method"] = str(merged.get("method") or "POST").upper()
+    merged["content_type"] = str(merged.get("content_type") or "application/json")
+    if not isinstance(merged.get("headers"), dict):
+        merged["headers"] = {}
+    merged["body"] = str(merged.get("body") or "")
+    try:
+        merged["timeout"] = max(1, int(merged.get("timeout", 5)))
+    except (TypeError, ValueError):
+        merged["timeout"] = 5
+    return merged
+
+
+def load_config(path: str = CONFIG_PATH) -> Dict[str, Any]:
+    if not os.path.exists(path):
+        return default_config()
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            return _merge_with_defaults(json.load(f))
+    except Exception:
+        return default_config()
+
+
+def save_config(config: Dict[str, Any], path: str = CONFIG_PATH) -> Dict[str, Any]:
+    merged = _merge_with_defaults(config)
+    if merged["content_type"].lower().startswith("application/json") and merged.get("body"):
+        # Validate the JSON template itself before saving. Placeholders are
+        # rendered after parsing, so runtime content cannot break valid JSON.
+        json.loads(merged["body"])
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump(merged, f, ensure_ascii=False, indent=2)
+    return merged
+
+
+def _render(value: Any, title: str, content: str) -> Any:
+    if isinstance(value, str):
+        return value.replace("$title", title).replace("$content", content)
+    if isinstance(value, dict):
+        return {k: _render(v, title, content) for k, v in value.items()}
+    if isinstance(value, list):
+        return [_render(item, title, content) for item in value]
+    return value
+
+
+def send_webhook(title: str, content: str, config: Optional[Dict[str, Any]] = None) -> Tuple[bool, str]:
+    cfg = _merge_with_defaults(config if config is not None else load_config())
+    if not cfg["enabled"]:
+        return True, "Webhook disabled"
+    url = str(cfg.get("url") or "").strip()
+    if not url:
+        return False, "Webhook URL is required"
+
+    method = cfg["method"]
+    headers = deepcopy(cfg.get("headers") or {})
+    content_type = cfg.get("content_type") or "application/json"
+    headers.setdefault("Content-Type", content_type)
+    headers = _render(headers, title, content)
+
+    kwargs: Dict[str, Any] = {"headers": headers, "timeout": cfg["timeout"]}
+    if content_type.lower().startswith("application/json"):
+        try:
+            # Parse the JSON template before rendering placeholders. Runtime error
+            # content often contains newlines, quotes, and traceback snippets; if we
+            # render first, those characters can break the JSON string itself.
+            body_json = json.loads(cfg.get("body", "")) if cfg.get("body", "") else {}
+            kwargs["json"] = _render(body_json, title, content)
+        except json.JSONDecodeError:
+            return False, "Webhook JSON body is invalid"
+    else:
+        body = _render(cfg.get("body", ""), title, content)
+        kwargs["data"] = body
+
+    try:
+        response = requests.request(method, url, **kwargs)
+        response_text = response.text or ""
+        if 200 <= response.status_code < 300:
+            # Some webhook providers, including Feishu/Lark, return HTTP 200
+            # even when the message is rejected at the application layer.
+            try:
+                response_json = response.json()
+            except Exception:
+                try:
+                    response_json = json.loads(response_text) if response_text else {}
+                except Exception:
+                    response_json = {}
+            if isinstance(response_json, dict):
+                code = response_json.get("code")
+                status_code = response_json.get("StatusCode")
+                if code not in (None, 0):
+                    return False, f"Webhook provider rejected message: code={code}, msg={response_json.get('msg') or response_json.get('message') or response_text[:200]}"
+                if status_code not in (None, 0):
+                    return False, f"Webhook provider rejected message: StatusCode={status_code}, msg={response_json.get('StatusMessage') or response_text[:200]}"
+            return True, f"Webhook sent: HTTP {response.status_code}"
+        return False, f"Webhook failed: HTTP {response.status_code} {response_text[:200]}"
+    except Exception as exc:
+        return False, f"Webhook request error: {exc}"
+
+
+def send_message(title: str, content: str) -> Tuple[bool, str]:
+    """Convenience wrapper used by runtime notification paths."""
+    return send_webhook(title, content)

--- a/wxbot_core.py
+++ b/wxbot_core.py
@@ -54,6 +54,7 @@ is_wxautox = True  # 标识当前使用的是 wxautox Plus 版本
 # 本地模块导入
 # ============================================================
 import email_send
+import webhook_send
 from logger import log
 
 # ============================================================
@@ -1737,17 +1738,24 @@ class WXBot:
 
     def is_err(self, id, err="无"):
         """
-        记录错误信息并发送告警邮件。
+        记录错误信息并发送告警通知。
 
         :param id:  错误标题（邮件主题）
         :param err: 错误详情（可为异常对象或字符串）
         """
         print(traceback.format_exc())
         log(level="ERROR", message=f"出现错误：{err}")
-        email_send.send_email(
-            subject=id,
-            content='错误信息：\n' + traceback.format_exc() + "\nerr信息：\n" + str(err),
-        )
+        content = '错误信息：\n' + traceback.format_exc() + "\nerr信息：\n" + str(err)
+        try:
+            email_send.send_email(subject=id, content=content)
+        except Exception as e:
+            log(level="ERROR", message=f"发送告警邮件失败：{e}")
+        try:
+            ok, message = webhook_send.send_message(id, content)
+            if not ok:
+                log(level="ERROR", message=f"发送 Webhook 告警失败：{message}")
+        except Exception as e:
+            log(level="ERROR", message=f"发送 Webhook 告警异常：{e}")
 
     def key_pass(self, year, month, day, hour, minute, second):
         """


### PR DESCRIPTION
## 变更内容
- 新增通用 Webhook 通知模块，与现有邮件报错通知并列使用，不影响原邮箱功能。
- 在管理后台新增 Webhook 通知配置页面，支持保存、读取和发送测试消息。
- 支持完整 Webhook URL、请求方法、Content-Type、Headers、Body 模板、超时时间等配置。
- Body 和 Headers 支持 `` / `` 占位符，便于接入飞书、钉钉、企业微信、Discord 等机器人。
- 在现有 `is_err` 报错链路中并列触发 Webhook，发送失败只记录日志，不影响机器人主流程。
- 兼容飞书这类 HTTP 200 但业务层返回错误码的场景，避免页面误提示发送成功。

## 测试
- `python3 -m unittest discover -s tests -v`
- `python3 -m compileall -q webhook_send.py web_server.py wxbot_core.py`

## 说明
- 邮件通知逻辑保持不变。
- Webhook URL 使用用户复制到的完整链接，无需手动去掉前缀或只填写 token。
- 默认模板兼容飞书文本机器人，同时也可以在页面中自定义请求体。