### PR TITLE
增加接口测试、思考清洗与回复次数限制

### DIFF
--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -192,6 +192,10 @@ body { background: var(--bg); font-family: -apple-system, BlinkMacSystemFont, "S
 .form-control:focus, .form-select:focus { border-color: var(--primary); box-shadow: 0 0 0 3px rgba(7,193,96,.12); background: #fff; color: var(--card-fg); outline: none; }
 .form-check-input:checked { background-color: var(--primary); border-color: var(--primary); }
 .form-check-label { font-size: 13.5px; color: var(--card-fg); }
+.inline-check-field { display: flex; align-items: stretch; width: 100%; }
+.inline-check-field .form-control { flex: 1; min-width: 0; border-top-right-radius: 0; border-bottom-right-radius: 0; }
+.inline-check-suffix { display: inline-flex; align-items: center; gap: 8px; min-height: 38px; padding: 0 14px; border: 1px solid var(--border); border-left: 0; border-radius: 0 6px 6px 0; background: #fff; color: var(--card-fg); font-size: 13.5px; font-weight: 500; white-space: nowrap; cursor: pointer; }
+.inline-check-suffix .form-check-input { margin: 0; width: 16px; height: 16px; flex-shrink: 0; }
 
 /* ===== List Items ===== */
 .list-item { display: flex; align-items: center; gap: 8px; margin-bottom: 8px; }
@@ -445,6 +449,19 @@ body.mobile-nav-open { overflow: hidden; }
   .cfg-card-header .desc {
     width: 100%;
     margin-left: 0;
+  }
+  .inline-check-field {
+    flex-wrap: wrap;
+    gap: 8px;
+  }
+  .inline-check-field .form-control {
+    flex-basis: 100%;
+    border-radius: 6px;
+  }
+  .inline-check-suffix {
+    min-height: 36px;
+    border-left: 1px solid var(--border);
+    border-radius: 6px;
   }
 
   .list-item,
@@ -946,6 +963,11 @@ body.mobile-nav-open { overflow: hidden; }
           <div class="stat-val" id="sv-delay">-</div>
           <div class="stat-label">回复延迟</div>
         </div>
+        <div class="stat-card" id="sc-max-round">
+          <div class="stat-icon"><i class="bi bi-shield-check"></i></div>
+          <div class="stat-val" id="sv-max-round">-</div>
+          <div class="stat-label">轮数限制</div>
+        </div>
       </div>
       <!-- 详情行 -->
       <div style="display:grid;grid-template-columns:1fr 1fr;gap:10px;">
@@ -1272,7 +1294,7 @@ body.mobile-nav-open { overflow: hidden; }
         <span id="listenModeText">{% if config.AllListen_switch %}当前为黑名单模式 — 以下用户的消息将被忽略{% else %}当前为白名单模式 — 仅监听以下用户的消息{% endif %}</span>
       </div>
       <div class="mb-2">
-        <label class="cfg-label" id="listenListLabel">{% if config.AllListen_switch %}黑名单列表{% else %}监听列表 <span style="font-size:11px;color:var(--muted);font-weight:400;">（白名单模式：可为每个用户设置专属 Prompt 和接口）</span>{% endif %}</label>
+        <label class="cfg-label" id="listenListLabel">{% if config.AllListen_switch %}黑名单列表{% else %}监听列表 <span style="font-size:11px;color:var(--muted);font-weight:400;">（白名单模式：可为每个用户设置专属 Prompt、接口和回复上限）</span>{% endif %}</label>
       </div>
       <div id="listen_container">
         {% for item in config.listen_list %}
@@ -1291,6 +1313,9 @@ body.mobile-nav-open { overflow: hidden; }
               <option value="{{ loop.index0 }}" {% if config.chat_api_map.get(item) == loop.index0 %}selected{% endif %}>接口{{ loop.index }}: {{ cfg.model }}</option>
               {% endfor %}
             </select>
+            <input type="number" class="form-control chat-max-round-input" min="1" max="99999"
+                   value="{{ config.get('chat_max_round_map', {}).get(item, '') }}"
+                   placeholder="全局上限" title="专属回复上限（留空=全局）" style="width:120px;flex-shrink:0;">
           </div>
           <button type="button" class="btn-rm btn-remove-item"><i class="bi bi-x-lg"></i></button>
         </div>
@@ -2104,13 +2129,52 @@ body.mobile-nav-open { overflow: hidden; }
         </div>
         <div class="cfg-hint" style="margin-top:8px;">实际延迟为最小值到最大值之间的随机整数秒 · 若最小值大于最大值则自动互换</div>
       </div>
-      <hr style="margin:18px 0 14px;">
       <div class="mb-2">
         <label class="cfg-label" for="api_error_reply" style="font-weight:600;">接口调用失败固定回复</label>
-        <input type="text" class="form-control" id="api_error_reply"
-               value="{{ config.get('api_error_reply', '在忙，我稍后回复您') }}"
-               placeholder="在忙，我稍后回复您">
+        <div class="inline-check-field">
+          <input type="text" class="form-control" id="api_error_reply"
+                 value="{{ config.get('api_error_reply', '在忙，我稍后回复您') }}"
+                 placeholder="在忙，我稍后回复您">
+          <label class="inline-check-suffix" for="api_error_reply_once">
+            <input class="form-check-input" type="checkbox" id="api_error_reply_once" {% if config.get('api_error_reply_once', False) %}checked{% endif %}>
+            只回复一次
+          </label>
+        </div>
         <div class="cfg-hint" style="margin-top:6px;">当调用 AI / 模型接口失败时，机器人将发送此固定回复，而非原始报错提示。</div>
+      </div>
+      <div class="switch-row">
+        <input class="form-check-input" type="checkbox" id="chat_max_round_switch" {% if config.get('chat_max_round_switch', False) %}checked{% endif %}>
+        <label for="chat_max_round_switch">启用回复次数限制（单个好友）</label>
+        <span class="switch-desc">超出设定次数后不再调用 AI 自动回复</span>
+      </div>
+      <div id="chat-max-round-settings" style="{% if not config.get('chat_max_round_switch', False) %}display:none;{% endif %}">
+        <div class="row g-3" style="margin-top:4px;">
+          <div class="col-6">
+            <label class="cfg-label" for="chat_max_round_default">单个好友最多回复次数</label>
+            <input type="number" class="form-control" id="chat_max_round_default" min="1" max="99999"
+              value="{{ config.get('chat_max_round_default', 99) }}" placeholder="99">
+            <div class="cfg-hint">此设置全局生效</div>
+          </div>
+          <div class="col-6">
+            <label class="cfg-label" for="chat_max_round_reset_days">计数重置周期（天）</label>
+            <input type="number" class="form-control" id="chat_max_round_reset_days" min="0" max="365"
+              value="{{ config.get('chat_max_round_reset_days', 0) }}" placeholder="0">
+            <div class="cfg-hint">0=永久累计，1=每天重置，7=每周重置，以此类推</div>
+          </div>
+        </div>
+        <div class="mb-2" style="margin-top:12px;">
+          <label class="cfg-label" for="chat_max_round_reply">超出次数限制固定回复</label>
+          <div class="inline-check-field">
+            <input type="text" class="form-control" id="chat_max_round_reply"
+                   value="{{ config.get('chat_max_round_reply', '') }}"
+                   placeholder="不填写则不回复">
+            <label class="inline-check-suffix" for="chat_max_round_reply_once">
+              <input class="form-check-input" type="checkbox" id="chat_max_round_reply_once" {% if config.get('chat_max_round_reply_once', False) %}checked{% endif %}>
+              只回复一次
+            </label>
+          </div>
+          <div class="cfg-hint">当单个用户回复次数超限时，机器人将发送此固定回复，留空则不回复。</div>
+        </div>
       </div>
       <div class="switch-row">
         <input class="form-check-input" type="checkbox" id="clean_ai_reply_switch" {% if config.get('clean_ai_reply_switch', True) %}checked{% endif %}>
@@ -2852,6 +2916,11 @@ $(function(){
     $('#reply-delay-settings').toggle(this.checked);
   });
 
+  // ===== 回复轮数限制开关联动 =====
+  $('#chat_max_round_switch').on('change', function(){
+    $('#chat-max-round-settings').toggle(this.checked);
+  });
+
   // ===== Remove List Item =====
   $(document).on('click','.btn-remove-item',function(){
     $(this).closest('.list-item, .keyword-item, .scheduled-msg-item, .scheduled-moments-item, .random-moments-item, .random-msg-item, .custom-forward-item').remove();
@@ -3008,7 +3077,7 @@ $(function(){
       $('#global-prompt-row').hide();
       $('#global-filter-mute-row').hide();
       $('.listen-extra').show();
-      $('#listenListLabel').html('监听列表 <span style="font-size:11px;color:var(--muted);font-weight:400;">（白名单模式：可为每个用户设置专属 Prompt 和接口）</span>');
+      $('#listenListLabel').html('监听列表 <span style="font-size:11px;color:var(--muted);font-weight:400;">（白名单模式：可为每个用户设置专属 Prompt、接口和回复上限）</span>');
     }
     $('#listenAddText').text(isGlobal ? '添加黑名单' : '添加监听');
   }
@@ -3022,6 +3091,7 @@ $(function(){
       '<div class="listen-extra" style="display:flex;gap:6px;flex-wrap:wrap;">'+
         '<select class="form-select chat-prompt-select" style="width:145px;flex-shrink:0;" title="专属Prompt">'+buildPromptOpts('')+'</select>'+
         '<select class="form-select chat-api-select" style="width:160px;flex-shrink:0;" title="专属接口">'+buildChatApiOpts(-1)+'</select>'+
+        '<input type="number" class="form-control chat-max-round-input" min="1" max="99999" placeholder="全局上限" title="专属回复上限（留空=全局）" style="width:120px;flex-shrink:0;">'+
       '</div>';
     $('#listen_container').append(
       '<div class="list-item listen-item" style="flex-wrap:wrap;gap:6px;">'+
@@ -3556,7 +3626,7 @@ $(function(){
       group_welcome_msg:$('#group_welcome_msg').summernote('code'),
       default_prompt:$('#default_prompt_select').val()||'默认',
       listen_list:[], group:[], group_api_map:{}, group_prompt_map:{}, new_friend_msg:[],
-      chat_prompt_map:{}, chat_api_map:{},
+      chat_prompt_map:{}, chat_api_map:{}, chat_max_round_map:{},
       group_welcome_random:parseFloat($('#group_welcome_random').val()),
       keyword_dict:{},
       scheduled_msg_switch:$('#scheduled_msg_switch').is(':checked'),
@@ -3584,7 +3654,13 @@ $(function(){
       group_image_recognition_switch:$('#group_image_recognition_switch').is(':checked'),
       group_image_recognition_api:parseInt($('#group_image_recognition_api').val())||0,
       api_error_reply:$('#api_error_reply').val().trim()||'在忙，我稍后回复您',
+      api_error_reply_once:$('#api_error_reply_once').is(':checked'),
       clean_ai_reply_switch:$('#clean_ai_reply_switch').is(':checked'),
+      chat_max_round_switch:$('#chat_max_round_switch').is(':checked'),
+      chat_max_round_default:Math.max(1,Math.min(99999,parseInt($('#chat_max_round_default').val())||99)),
+      chat_max_round_reset_days:Math.max(0,Math.min(365,parseInt($('#chat_max_round_reset_days').val())||0)),
+      chat_max_round_reply:$('#chat_max_round_reply').val().trim(),
+      chat_max_round_reply_once:$('#chat_max_round_reply_once').is(':checked'),
       chat_split_reply_switch:$('#chat_split_reply_switch').is(':checked'),
       chat_split_max_chars:Math.max(1,parseInt($('#chat_split_max_chars').val())||100),
       chat_split_max_count:Math.max(1,parseInt($('#chat_split_max_count').val())||4),
@@ -3607,6 +3683,8 @@ $(function(){
         if (pv) configData.chat_prompt_map[uname] = pv;
         var av = parseInt($(this).find('.chat-api-select').val());
         if (!isNaN(av) && av >= 0) configData.chat_api_map[uname] = av;
+        var rv = parseInt($(this).find('.chat-max-round-input').val());
+        if (!isNaN(rv) && rv >= 1) configData.chat_max_round_map[uname] = Math.min(99999, rv);
       }
     });
     // 群组：收集名称列表 + 专属接口映射 + 专属 prompt 映射
@@ -4069,6 +4147,13 @@ $(function(){
         $('#sv-memory').text(d.memory_switch ? ('上下文' + (d.memory_context_count||'-') + '条') : '未启用');
         // 回复延迟卡片
         $('#sv-delay').text(d.reply_delay_switch ? ((d.reply_delay_min||'-') + '~' + (d.reply_delay_max||'-') + 's') : '未启用');
+        // 回复轮数限制卡片
+        if (d.chat_max_round_switch) {
+          var resetText = d.chat_max_round_reset_days ? ('/' + d.chat_max_round_reset_days + '天') : '';
+          $('#sv-max-round').text('上限' + (d.chat_max_round_default||'-') + '轮' + resetText);
+        } else {
+          $('#sv-max-round').text('未启用');
+        }
         // 详情行
         $('#dv-kw-at').text(d.group_keyword_switch ? (d.group_keyword_at_only ? '仅@触发' : '全部触发') : '-');
         $('#dv-mem-ctx').text(d.memory_switch ? ((d.memory_context_count||'-') + ' 条') : '已关闭');

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -1158,9 +1158,14 @@ body.mobile-nav-open { overflow: hidden; }
         </div>
         {% endfor %}
       </div>
-      <button type="button" id="btn-add-api-config" style="width:100%;background:var(--muted-bg);border:1px dashed var(--border);color:var(--muted);padding:10px;border-radius:6px;font-size:13px;margin-top:4px;cursor:pointer;">
-        <i class="bi bi-plus-circle"></i> 添加接口配置
-      </button>
+      <div style="display:flex;gap:10px;align-items:center;margin-top:4px;flex-wrap:wrap;">
+        <button type="button" id="btn-test-api-config" style="flex:0 0 180px;background:var(--card);border:1px solid var(--border);color:var(--card-fg);padding:10px;border-radius:6px;font-size:13px;font-weight:600;cursor:pointer;">
+          <i class="bi bi-activity"></i> 测试可用性
+        </button>
+        <button type="button" id="btn-add-api-config" style="flex:1;min-width:220px;background:var(--muted-bg);border:1px dashed var(--border);color:var(--muted);padding:10px;border-radius:6px;font-size:13px;cursor:pointer;">
+          <i class="bi bi-plus-circle"></i> 添加接口配置
+        </button>
+      </div>
       <div class="cfg-hint" style="margin-top:8px;">点击左侧单选框选择当前使用的接口 · 选择 DusAPI 时接口地址自动填写 · <a href="https://dusapi.com" target="_blank" style="color:#07C160;">dusapi.com 获取 Key</a></div>
     </div>
   </div>
@@ -2107,6 +2112,11 @@ body.mobile-nav-open { overflow: hidden; }
                placeholder="在忙，我稍后回复您">
         <div class="cfg-hint" style="margin-top:6px;">当调用 AI / 模型接口失败时，机器人将发送此固定回复，而非原始报错提示。</div>
       </div>
+      <div class="switch-row">
+        <input class="form-check-input" type="checkbox" id="clean_ai_reply_switch" {% if config.get('clean_ai_reply_switch', True) %}checked{% endif %}>
+        <label for="clean_ai_reply_switch">屏蔽模型思考过程</label>
+        <span class="switch-desc">自动移除模型返回的思考标签，避免将推理过程发送给用户</span>
+      </div>
     </div>
   </div>
 
@@ -2589,6 +2599,20 @@ $(function(){
     }
   });
 
+  function getApiConfigFromItem($item){
+    var $k = $item.find('.api-key-input');
+    var typedKey = $k.val();
+    var maskedKey = $k.data('masked') || '';
+    var realKey = $k.data('real-key') || '';
+    var keyToUse = (typedKey === maskedKey || typedKey === '') ? realKey : typedKey;
+    return {
+      sdk: $item.find('.api-sdk-select').val(),
+      model: $item.find('.api-model-input').val(),
+      url: $item.find('.api-url-input').val(),
+      key: keyToUse
+    };
+  }
+
   // ===== 接口配置：SDK 变更自动填写 URL + 显示 DusAPI 提示 =====
   $(document).on('change', '.api-sdk-select', function(){
     var $item = $(this).closest('.api-config-item');
@@ -2613,6 +2637,55 @@ $(function(){
     if($('.api-config-item').length <= 2){ svModal.alert('至少保留 2 个接口配置'); return; }
     $(this).closest('.api-config-item').remove();
     renumberApiConfigs();
+  });
+
+  // ===== 接口配置：测试当前选中接口 =====
+  $('#btn-test-api-config').click(function(){
+    var $btn = $(this);
+    var $item = $('.api-config-item').has('.api-radio:checked').first();
+    if(!$item.length){
+      svModal.error('请先选择一个接口配置');
+      return;
+    }
+    var apiConfig = getApiConfigFromItem($item);
+    if(!apiConfig.key || !apiConfig.url || !apiConfig.model){
+      svModal.error('请先填写当前选中接口的 API Key、Base URL 和模型名称');
+      return;
+    }
+    var idx = $('.api-config-item').index($item) + 1;
+    $btn.prop('disabled', true).html('<i class="bi bi-hourglass-split"></i> 测试中...');
+    $.ajax({
+      url: '/test_api_config',
+      method: 'POST',
+      contentType: 'application/json',
+      dataType: 'json',
+      timeout: 70000,
+      data: JSON.stringify({api_config: apiConfig}),
+      success: function(res){
+        if(res.status === 'success'){
+          var d = res.data || {};
+          var cleanedHint = d.cleaned ? '<br><br>检测到思考标签，已按当前清洗规则处理测试返回。' : '';
+          svModal.success(
+            '接口 ' + idx + ' 可用<br>' +
+            '耗时：' + (d.elapsed_ms || '-') + ' ms<br>' +
+            '返回：<code>' + $('<div>').text(d.reply || '').html() + '</code>' +
+            cleanedHint,
+            '测试成功'
+          );
+        } else {
+          svModal.error(res.message || '接口测试失败', '测试失败');
+        }
+      },
+      error: function(xhr){
+        var msg = '接口测试请求失败';
+        if(xhr.responseJSON && xhr.responseJSON.message) msg = xhr.responseJSON.message;
+        else if(xhr.status) msg += '：HTTP ' + xhr.status;
+        svModal.error(msg, '测试失败');
+      },
+      complete: function(){
+        $btn.prop('disabled', false).html('<i class="bi bi-activity"></i> 测试可用性');
+      }
+    });
   });
 
   // ===== 接口配置：添加 =====
@@ -3511,6 +3584,7 @@ $(function(){
       group_image_recognition_switch:$('#group_image_recognition_switch').is(':checked'),
       group_image_recognition_api:parseInt($('#group_image_recognition_api').val())||0,
       api_error_reply:$('#api_error_reply').val().trim()||'在忙，我稍后回复您',
+      clean_ai_reply_switch:$('#clean_ai_reply_switch').is(':checked'),
       chat_split_reply_switch:$('#chat_split_reply_switch').is(':checked'),
       chat_split_max_chars:Math.max(1,parseInt($('#chat_split_max_chars').val())||100),
       chat_split_max_count:Math.max(1,parseInt($('#chat_split_max_count').val())||4),

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -919,7 +919,7 @@ body.mobile-nav-open { overflow: hidden; }
       <!-- 统计卡片网格 -->
       <div style="display:grid;grid-template-columns:repeat(auto-fill,minmax(160px,1fr));gap:12px;margin-bottom:20px;">
         <div class="stat-card" id="sc-received">
-          <div class="stat-icon"><i class="bi bi-envelope-arrow-down"></i></div>
+          <div class="stat-icon"><i class="bi bi-inbox"></i></div>
           <div class="stat-val" id="sv-received">-</div>
           <div class="stat-label">收到消息</div>
         </div>
@@ -954,7 +954,7 @@ body.mobile-nav-open { overflow: hidden; }
           <div class="stat-label">关键词回复</div>
         </div>
         <div class="stat-card" id="sc-memory">
-          <div class="stat-icon"><i class="bi bi-brain"></i></div>
+          <div class="stat-icon"><i class="bi bi-journal-text"></i></div>
           <div class="stat-val" id="sv-memory">-</div>
           <div class="stat-label">对话记忆</div>
         </div>
@@ -1350,8 +1350,8 @@ body.mobile-nav-open { overflow: hidden; }
       </div>
       <div style="padding:9px 14px;background:#fffbeb;border:1px solid #fcd34d;border-radius:6px;color:#92400e;font-size:12.5px;line-height:1.8;">
         <i class="bi bi-exclamation-triangle" style="color:#d97706;margin-right:4px;"></i>
-        <strong>图片识别：</strong>目前仅支持 <a href="https://dusapi.com" target="_blank" style="color:#92400e;font-weight:600;">DusAPI</a> 接口，需选择支持视觉的模型，如 <strong>claude-sonnet-4-6</strong>、<strong>gpt-5.4</strong> 系列。
-        支持<strong>直接发送</strong>的图片及<strong>引用图片</strong>的识别。DusAPI 原生支持图片识别，和配置其他功能一样，填个 Key 即可通用，快速便捷。
+        <strong>图片识别：</strong>支持 <a href="https://dusapi.com" target="_blank" style="color:#92400e;font-weight:600;">DusAPI</a>，以及兼容 OpenAI 视觉格式的接口（如 Kimi / OpenAI），需选择支持视觉输入的模型。
+        支持<strong>直接发送</strong>的图片及<strong>引用图片</strong>的识别。MiniMax、DeepSeek 当前不建议用于图片识别。
         遇到图片下载、保存或识图相关报错时，请尝试：将 <strong>Windows 屏幕缩放设置为 100%</strong>，并将<strong>微信字体保持标准大小</strong>后重试。
         <br><strong>语音识别：</strong>开启后会自动调用微信的语音消息转文字功能，仅能识别普通话。如果提示转文字失败，请在微信设置 → 通用 → 聊天中，将「语音消息自动转成文字」功能打开。
       </div>
@@ -1483,8 +1483,8 @@ body.mobile-nav-open { overflow: hidden; }
       </div>
       <div style="padding:9px 14px;background:#fffbeb;border:1px solid #fcd34d;border-radius:6px;color:#92400e;font-size:12.5px;line-height:1.8;">
         <i class="bi bi-exclamation-triangle" style="color:#d97706;margin-right:4px;"></i>
-        图片识别目前仅支持 <a href="https://dusapi.com" target="_blank" style="color:#92400e;font-weight:600;">DusAPI</a> 接口，需选择支持视觉的模型，如 <strong>claude-sonnet-4-6</strong>、<strong>gpt-5.4</strong> 系列。
-        支持<strong>直接发送</strong>的图片及<strong>引用图片</strong>的识别。DusAPI 原生支持图片识别，和配置其他功能一样，填个 Key 即可通用，快速便捷。
+        图片识别支持 <a href="https://dusapi.com" target="_blank" style="color:#92400e;font-weight:600;">DusAPI</a>，以及兼容 OpenAI 视觉格式的接口（如 Kimi / OpenAI），需选择支持视觉输入的模型。
+        支持<strong>直接发送</strong>的图片及<strong>引用图片</strong>的识别。MiniMax、DeepSeek 当前不建议用于图片识别。
         遇到图片下载、保存或识图相关报错时，请尝试：将 <strong>Windows 屏幕缩放设置为 100%</strong>，并将<strong>微信字体保持标准大小</strong>后重试。
         <br><strong>语音识别：</strong>开启后会自动调用微信的语音消息转文字功能，仅能识别普通话。如果提示转文字失败，请在微信设置 → 通用 → 聊天中，将「语音消息自动转成文字」功能打开。
       </div>
@@ -2723,15 +2723,27 @@ $(function(){
       method: 'POST',
       contentType: 'application/json',
       dataType: 'json',
-      timeout: 70000,
+      timeout: 140000,
       data: JSON.stringify({api_config: apiConfig}),
       success: function(res){
         if(res.status === 'success'){
           var d = res.data || {};
           var cleanedHint = d.cleaned ? '<br><br>检测到思考标签，已按当前清洗规则处理测试返回。' : '';
+          var img = d.image_test || {};
+          var imageHtml = '<br>图片：';
+          if(img.status === 'success'){
+            imageHtml += '<span style="color:#07C160;font-weight:600;">可用</span>';
+            if(img.cleaned) imageHtml += '（已清洗测试返回）';
+          } else if(img.status === 'skipped'){
+            imageHtml += '<span style="color:#888;">未测试</span>：' + $('<div>').text(img.message || '').html();
+          } else {
+            imageHtml += '<span style="color:#FA5151;font-weight:600;">失败</span>：' + $('<div>').text(img.message || '').html();
+          }
           svModal.success(
             '接口 ' + idx + ' 可用<br>' +
             '耗时：' + (d.elapsed_ms || '-') + ' ms<br>' +
+            '文本：<span style="color:#07C160;font-weight:600;">可用</span>' +
+            imageHtml + '<br>' +
             '返回：<code>' + $('<div>').text(d.reply || '').html() + '</code>' +
             cleanedHint,
             '测试成功'

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -1350,8 +1350,8 @@ body.mobile-nav-open { overflow: hidden; }
       </div>
       <div style="padding:9px 14px;background:#fffbeb;border:1px solid #fcd34d;border-radius:6px;color:#92400e;font-size:12.5px;line-height:1.8;">
         <i class="bi bi-exclamation-triangle" style="color:#d97706;margin-right:4px;"></i>
-        <strong>图片识别：</strong>支持 <a href="https://dusapi.com" target="_blank" style="color:#92400e;font-weight:600;">DusAPI</a>，以及兼容 OpenAI 视觉格式的接口（如 Kimi / OpenAI），需选择支持视觉输入的模型。
-        支持<strong>直接发送</strong>的图片及<strong>引用图片</strong>的识别。MiniMax、DeepSeek 当前不建议用于图片识别。
+        <strong>图片识别：</strong>支持 <a href="https://dusapi.com" target="_blank" style="color:#92400e;font-weight:600;">DusAPI</a>，以及兼容 OpenAI 视觉格式的接口（比如 Kimi），需选择支持视觉输入的模型。
+        支持<strong>直接发送</strong>的图片及<strong>引用图片</strong>的识别。DusAPI 原生支持图片识别，和配置其他功能一样，填个 Key 即可通用，快速便捷。
         遇到图片下载、保存或识图相关报错时，请尝试：将 <strong>Windows 屏幕缩放设置为 100%</strong>，并将<strong>微信字体保持标准大小</strong>后重试。
         <br><strong>语音识别：</strong>开启后会自动调用微信的语音消息转文字功能，仅能识别普通话。如果提示转文字失败，请在微信设置 → 通用 → 聊天中，将「语音消息自动转成文字」功能打开。
       </div>
@@ -1483,8 +1483,8 @@ body.mobile-nav-open { overflow: hidden; }
       </div>
       <div style="padding:9px 14px;background:#fffbeb;border:1px solid #fcd34d;border-radius:6px;color:#92400e;font-size:12.5px;line-height:1.8;">
         <i class="bi bi-exclamation-triangle" style="color:#d97706;margin-right:4px;"></i>
-        图片识别支持 <a href="https://dusapi.com" target="_blank" style="color:#92400e;font-weight:600;">DusAPI</a>，以及兼容 OpenAI 视觉格式的接口（如 Kimi / OpenAI），需选择支持视觉输入的模型。
-        支持<strong>直接发送</strong>的图片及<strong>引用图片</strong>的识别。MiniMax、DeepSeek 当前不建议用于图片识别。
+        图片识别支持 <a href="https://dusapi.com" target="_blank" style="color:#92400e;font-weight:600;">DusAPI</a>，以及兼容 OpenAI 视觉格式的接口（比如 Kimi），需选择支持视觉输入的模型。
+        支持<strong>直接发送</strong>的图片及<strong>引用图片</strong>的识别。DusAPI 原生支持图片识别，和配置其他功能一样，填个 Key 即可通用，快速便捷。
         遇到图片下载、保存或识图相关报错时，请尝试：将 <strong>Windows 屏幕缩放设置为 100%</strong>，并将<strong>微信字体保持标准大小</strong>后重试。
         <br><strong>语音识别：</strong>开启后会自动调用微信的语音消息转文字功能，仅能识别普通话。如果提示转文字失败，请在微信设置 → 通用 → 聊天中，将「语音消息自动转成文字」功能打开。
       </div>

--- a/tests/test_ai_reply_cleaner.py
+++ b/tests/test_ai_reply_cleaner.py
@@ -1,0 +1,95 @@
+import sys
+import types
+import unittest
+
+
+def _install_import_stubs():
+    wxautox4 = types.ModuleType("wxautox4")
+    wxautox4.WeChat = object
+    wxautox4.WxParam = types.SimpleNamespace(
+        MESSAGE_HASH=False,
+        FORCE_MESSAGE_XBIAS=False,
+        CHAT_WINDOW_SIZE=None,
+        DEFAULT_MESSAGE_YBIAS=0,
+    )
+    sys.modules.setdefault("wxautox4", wxautox4)
+
+    msgs = types.ModuleType("wxautox4.msgs")
+    msgs.__all__ = []
+    sys.modules.setdefault("wxautox4.msgs", msgs)
+
+    useful = types.ModuleType("wxautox4.utils.useful")
+    useful.check_license = lambda *args, **kwargs: True
+    sys.modules.setdefault("wxautox4.utils.useful", useful)
+
+    email_send = types.ModuleType("email_send")
+    sys.modules.setdefault("email_send", email_send)
+
+    logger = types.ModuleType("logger")
+    logger.log = lambda *args, **kwargs: None
+    sys.modules.setdefault("logger", logger)
+
+    openai = types.ModuleType("openai")
+    openai.OpenAI = object
+    sys.modules.setdefault("openai", openai)
+
+    cozepy = types.ModuleType("cozepy")
+    for name in (
+        "COZE_CN_BASE_URL",
+        "Coze",
+        "TokenAuth",
+        "Message",
+        "ChatStatus",
+        "MessageContentType",
+        "ChatEventType",
+    ):
+        setattr(cozepy, name, object)
+    sys.modules.setdefault("cozepy", cozepy)
+
+    schedule = types.ModuleType("schedule")
+    sys.modules.setdefault("schedule", schedule)
+
+    requests = types.ModuleType("requests")
+    requests.post = lambda *args, **kwargs: None
+    requests.exceptions = types.SimpleNamespace(RequestException=Exception)
+    sys.modules.setdefault("requests", requests)
+
+
+_install_import_stubs()
+from wxbot_core import clean_ai_reply_text
+
+
+class AIReplyCleanerTests(unittest.TestCase):
+    def test_removes_complete_think_block(self):
+        text = '<think>内部推理\n不应发送</think>\n\n您好，有什么可以帮您的？'
+
+        self.assertEqual(clean_ai_reply_text(text), '您好，有什么可以帮您的？')
+
+    def test_removes_multiple_complete_think_blocks_case_insensitive(self):
+        text = '开头\n<THINK>一</THINK>\n中间\n<think>二</think>\n结尾'
+
+        self.assertEqual(clean_ai_reply_text(text), '开头\n中间\n结尾')
+
+    def test_removes_unclosed_leading_think_until_blank_line(self):
+        text = '<think>这里没有结束标签\n但是后面有正式回复\n\n您好'
+
+        self.assertEqual(clean_ai_reply_text(text), '您好')
+
+    def test_drops_unclosed_leading_think_when_no_safe_tail_exists(self):
+        text = '<think>这里没有结束标签，所以不能直接发给用户'
+
+        self.assertEqual(clean_ai_reply_text(text), '')
+
+    def test_keeps_unclosed_think_inside_normal_text(self):
+        text = '这是一段正常说明：<think> 是一个标签示例'
+
+        self.assertEqual(clean_ai_reply_text(text), text)
+
+    def test_keeps_plain_text_unchanged_except_outer_whitespace(self):
+        text = '  普通回复，不包含思考标签。  '
+
+        self.assertEqual(clean_ai_reply_text(text), '普通回复，不包含思考标签。')
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_api_config_image_test.py
+++ b/tests/test_api_config_image_test.py
@@ -1,0 +1,93 @@
+import sys
+import types
+import unittest
+
+
+def _install_import_stubs():
+    wxautox4 = types.ModuleType("wxautox4")
+    wxautox4.WeChat = object
+    wxautox4.WxParam = types.SimpleNamespace(
+        MESSAGE_HASH=False,
+        FORCE_MESSAGE_XBIAS=False,
+        CHAT_WINDOW_SIZE=None,
+        DEFAULT_MESSAGE_YBIAS=0,
+    )
+    sys.modules.setdefault("wxautox4", wxautox4)
+
+    msgs = types.ModuleType("wxautox4.msgs")
+    msgs.__all__ = []
+    sys.modules.setdefault("wxautox4.msgs", msgs)
+
+    useful = types.ModuleType("wxautox4.utils.useful")
+    useful.check_license = lambda *args, **kwargs: True
+    sys.modules.setdefault("wxautox4.utils.useful", useful)
+
+    email_send = types.ModuleType("email_send")
+    sys.modules.setdefault("email_send", email_send)
+
+    logger = types.ModuleType("logger")
+    logger.log = lambda *args, **kwargs: None
+    sys.modules.setdefault("logger", logger)
+
+    openai = types.ModuleType("openai")
+    openai.OpenAI = object
+    sys.modules.setdefault("openai", openai)
+
+    cozepy = types.ModuleType("cozepy")
+    for name in (
+        "COZE_CN_BASE_URL",
+        "Coze",
+        "TokenAuth",
+        "Message",
+        "ChatStatus",
+        "MessageContentType",
+        "ChatEventType",
+    ):
+        setattr(cozepy, name, object)
+    sys.modules.setdefault("cozepy", cozepy)
+
+    schedule = types.ModuleType("schedule")
+    sys.modules.setdefault("schedule", schedule)
+
+    requests = types.ModuleType("requests")
+    requests.post = lambda *args, **kwargs: None
+    requests.exceptions = types.SimpleNamespace(RequestException=Exception)
+    sys.modules.setdefault("requests", requests)
+
+
+class FakeVisionAPI:
+    def __init__(self):
+        self.image_path_seen = None
+
+    def chat(self, message, stream=False, prompt=None, history=None, image_path=""):
+        self.image_path_seen = image_path
+        return "OK"
+
+
+class FakeTextOnlyAPI:
+    def chat(self, message, stream=False, prompt=None, history=None):
+        return "OK"
+
+
+_install_import_stubs()
+import web_server
+
+
+class APIConfigImageTestTests(unittest.TestCase):
+    def test_image_test_uses_temporary_png_for_supported_api(self):
+        api = FakeVisionAPI()
+
+        result = web_server._run_api_image_test(api, "OpenAI SDK")
+
+        self.assertEqual(result["status"], "success")
+        self.assertTrue(api.image_path_seen.endswith(".png"))
+
+    def test_image_test_reports_unsupported_sdk(self):
+        result = web_server._run_api_image_test(FakeTextOnlyAPI(), "Dify")
+
+        self.assertEqual(result["status"], "skipped")
+        self.assertIn("暂不支持", result["message"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_openai_image_input.py
+++ b/tests/test_openai_image_input.py
@@ -1,0 +1,132 @@
+import base64
+import sys
+import tempfile
+import types
+import unittest
+from pathlib import Path
+
+
+def _install_import_stubs():
+    wxautox4 = types.ModuleType("wxautox4")
+    wxautox4.WeChat = object
+    wxautox4.WxParam = types.SimpleNamespace(
+        MESSAGE_HASH=False,
+        FORCE_MESSAGE_XBIAS=False,
+        CHAT_WINDOW_SIZE=None,
+        DEFAULT_MESSAGE_YBIAS=0,
+    )
+    sys.modules.setdefault("wxautox4", wxautox4)
+
+    msgs = types.ModuleType("wxautox4.msgs")
+    msgs.__all__ = []
+    sys.modules.setdefault("wxautox4.msgs", msgs)
+
+    useful = types.ModuleType("wxautox4.utils.useful")
+    useful.check_license = lambda *args, **kwargs: True
+    sys.modules.setdefault("wxautox4.utils.useful", useful)
+
+    email_send = types.ModuleType("email_send")
+    sys.modules.setdefault("email_send", email_send)
+
+    logger = types.ModuleType("logger")
+    logger.log = lambda *args, **kwargs: None
+    sys.modules.setdefault("logger", logger)
+
+    openai = types.ModuleType("openai")
+    openai.OpenAI = object
+    sys.modules.setdefault("openai", openai)
+
+    cozepy = types.ModuleType("cozepy")
+    for name in (
+        "COZE_CN_BASE_URL",
+        "Coze",
+        "TokenAuth",
+        "Message",
+        "ChatStatus",
+        "MessageContentType",
+        "ChatEventType",
+    ):
+        setattr(cozepy, name, object)
+    sys.modules.setdefault("cozepy", cozepy)
+
+    schedule = types.ModuleType("schedule")
+    sys.modules.setdefault("schedule", schedule)
+
+    requests = types.ModuleType("requests")
+    requests.post = lambda *args, **kwargs: None
+    requests.exceptions = types.SimpleNamespace(RequestException=Exception)
+    sys.modules.setdefault("requests", requests)
+
+
+class FakeCompletions:
+    def __init__(self):
+        self.kwargs = None
+
+    def create(self, **kwargs):
+        self.kwargs = kwargs
+        message = types.SimpleNamespace(content="OK")
+        choice = types.SimpleNamespace(message=message)
+        return types.SimpleNamespace(choices=[choice])
+
+
+class FakeClient:
+    def __init__(self):
+        self.chat = types.SimpleNamespace(completions=FakeCompletions())
+
+
+class FakeOpenAI:
+    last_client = None
+
+    def __new__(cls, *args, **kwargs):
+        cls.last_client = FakeClient()
+        return cls.last_client
+
+
+_install_import_stubs()
+import wxbot_core
+from wxbot_core import OpenAIAPI
+
+
+class OpenAIImageInputTests(unittest.TestCase):
+    def setUp(self):
+        wxbot_core.OpenAI = FakeOpenAI
+
+    def make_api(self):
+        config = types.SimpleNamespace(
+            api_key="sk-test",
+            base_url="https://api.moonshot.ai/v1",
+            model1="kimi-k2.6",
+            prompt="system prompt",
+        )
+        return OpenAIAPI(config)
+
+    def test_text_message_keeps_original_string_content(self):
+        api = self.make_api()
+
+        reply = api.chat("hello", stream=False)
+
+        self.assertEqual(reply, "OK")
+        messages = FakeOpenAI.last_client.chat.completions.kwargs["messages"]
+        self.assertEqual(messages[-1], {"role": "user", "content": "hello"})
+
+    def test_image_path_builds_openai_multimodal_content(self):
+        png_bytes = base64.b64decode(
+            "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII="
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            image_path = Path(tmp) / "tiny.png"
+            image_path.write_bytes(png_bytes)
+            api = self.make_api()
+
+            reply = api.chat("describe", stream=False, image_path=str(image_path))
+
+        self.assertEqual(reply, "OK")
+        messages = FakeOpenAI.last_client.chat.completions.kwargs["messages"]
+        content = messages[-1]["content"]
+        self.assertEqual(content[0], {"type": "text", "text": "describe"})
+        self.assertEqual(content[1]["type"], "image_url")
+        self.assertTrue(content[1]["image_url"]["url"].startswith("data:image/png;base64,"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_reply_count_store.py
+++ b/tests/test_reply_count_store.py
@@ -1,0 +1,140 @@
+import json
+import sys
+import tempfile
+import types
+import unittest
+from datetime import datetime
+from pathlib import Path
+
+
+def _install_import_stubs():
+    wxautox4 = types.ModuleType("wxautox4")
+    wxautox4.WeChat = object
+    wxautox4.WxParam = types.SimpleNamespace(
+        MESSAGE_HASH=False,
+        FORCE_MESSAGE_XBIAS=False,
+        CHAT_WINDOW_SIZE=None,
+        DEFAULT_MESSAGE_YBIAS=0,
+    )
+    sys.modules.setdefault("wxautox4", wxautox4)
+
+    msgs = types.ModuleType("wxautox4.msgs")
+    msgs.__all__ = []
+    sys.modules.setdefault("wxautox4.msgs", msgs)
+
+    useful = types.ModuleType("wxautox4.utils.useful")
+    useful.check_license = lambda *args, **kwargs: True
+    sys.modules.setdefault("wxautox4.utils.useful", useful)
+
+    email_send = types.ModuleType("email_send")
+    sys.modules.setdefault("email_send", email_send)
+
+    logger = types.ModuleType("logger")
+    logger.log = lambda *args, **kwargs: None
+    sys.modules.setdefault("logger", logger)
+
+    openai = types.ModuleType("openai")
+    openai.OpenAI = object
+    sys.modules.setdefault("openai", openai)
+
+    cozepy = types.ModuleType("cozepy")
+    for name in (
+        "COZE_CN_BASE_URL",
+        "Coze",
+        "TokenAuth",
+        "Message",
+        "ChatStatus",
+        "MessageContentType",
+        "ChatEventType",
+    ):
+        setattr(cozepy, name, object)
+    sys.modules.setdefault("cozepy", cozepy)
+
+    schedule = types.ModuleType("schedule")
+    sys.modules.setdefault("schedule", schedule)
+
+    requests = types.ModuleType("requests")
+    requests.post = lambda *args, **kwargs: None
+    requests.exceptions = types.SimpleNamespace(RequestException=Exception)
+    sys.modules.setdefault("requests", requests)
+
+
+_install_import_stubs()
+from wxbot_core import ReplyCountStore
+
+
+class ReplyCountStoreTests(unittest.TestCase):
+    def test_loads_empty_structure_when_file_is_missing(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "reply_count.json"
+            store = ReplyCountStore(str(path))
+
+            self.assertEqual(store.data["meta"]["last_reset_date"], "")
+            self.assertEqual(store.data["users"], {})
+
+    def test_repairs_corrupt_json(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "reply_count.json"
+            path.write_text("{bad json", encoding="utf-8")
+
+            store = ReplyCountStore(str(path))
+
+            self.assertEqual(store.data, {"meta": {"last_reset_date": ""}, "users": {}})
+
+    def test_increment_and_flags_are_persisted(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "reply_count.json"
+            store = ReplyCountStore(str(path))
+
+            self.assertEqual(store.increment_ai_count("alice"), 1)
+            self.assertTrue(store.mark_limit_notified("alice"))
+            self.assertFalse(store.mark_limit_notified("alice"))
+            self.assertTrue(store.mark_api_err_notified("alice"))
+            self.assertFalse(store.mark_api_err_notified("alice"))
+
+            saved = json.loads(path.read_text(encoding="utf-8"))
+            self.assertEqual(saved["users"]["alice"]["ai_count"], 1)
+            self.assertTrue(saved["users"]["alice"]["limit_notified"])
+            self.assertTrue(saved["users"]["alice"]["api_err_notified"])
+
+    def test_maybe_reset_clears_users_when_period_has_elapsed(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "reply_count.json"
+            path.write_text(
+                json.dumps({
+                    "meta": {"last_reset_date": "2026-05-01"},
+                    "users": {"alice": {"ai_count": 9}},
+                }),
+                encoding="utf-8",
+            )
+            store = ReplyCountStore(str(path))
+
+            did_reset = store.maybe_reset(7, now=datetime(2026, 5, 8, 8, 0, 0))
+
+            self.assertTrue(did_reset)
+            self.assertEqual(store.data["users"], {})
+            self.assertEqual(store.data["meta"]["last_reset_date"], "2026-05-08")
+
+    def test_clear_user_removes_only_target_user(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "reply_count.json"
+            store = ReplyCountStore(str(path))
+            store.increment_ai_count("alice")
+            store.increment_ai_count("bob")
+
+            self.assertTrue(store.clear_user("alice"))
+            self.assertFalse(store.clear_user("missing"))
+            self.assertNotIn("alice", store.data["users"])
+            self.assertIn("bob", store.data["users"])
+
+    def test_was_send_success_accepts_common_wx_response_shapes(self):
+        self.assertTrue(ReplyCountStore.was_send_success(True))
+        self.assertFalse(ReplyCountStore.was_send_success(False))
+        self.assertTrue(ReplyCountStore.was_send_success({"status": "success"}))
+        self.assertTrue(ReplyCountStore.was_send_success({"code": 0}))
+        self.assertFalse(ReplyCountStore.was_send_success({"status": "error"}))
+        self.assertFalse(ReplyCountStore.was_send_success(None))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/web_server.py
+++ b/web_server.py
@@ -708,8 +708,15 @@ def dashboard():
     config.setdefault('default_prompt', '默认')
     config.setdefault('chat_prompt_map', {})
     config.setdefault('chat_api_map', {})
+    config.setdefault('chat_max_round_map', {})
     config.setdefault('group_prompt_map', {})
     config.setdefault('api_error_reply', '在忙，我稍后回复您')   # 接口调用失败时的固定回复
+    config.setdefault('api_error_reply_once', False)       # 接口失败固定回复是否同一用户只发一次
+    config.setdefault('chat_max_round_switch', False)      # 单用户最大回复轮数限制开关
+    config.setdefault('chat_max_round_default', 99)        # 默认最多回复次数
+    config.setdefault('chat_max_round_reset_days', 0)      # 计数重置周期，0=不重置
+    config.setdefault('chat_max_round_reply', '')          # 超限后固定话术
+    config.setdefault('chat_max_round_reply_once', False)  # 超限话术是否同一用户只发一次
     config.setdefault('chat_split_reply_switch', False)   # 私聊拆分多条回复开关
     config.setdefault('chat_split_max_chars', 100)        # 私聊单条最大字数
     config.setdefault('chat_split_max_count', 4)          # 私聊最多条数
@@ -771,6 +778,9 @@ def _coerce_bool_fields(merged_config):
         'chat_split_reply_switch',          # 私聊拆分多条回复开关
         'group_split_reply_switch',         # 群聊拆分多条回复开关
         'siver_panel_enabled',
+        'api_error_reply_once',             # API错误只回复一次
+        'chat_max_round_switch',            # 单用户最大回复轮数限制开关
+        'chat_max_round_reply_once',        # 超限后只回复一次
     ]
     for field in boolean_fields:
         if field in merged_config:
@@ -808,6 +818,8 @@ def _coerce_int_range_fields(merged_config):
     int_range_fields = {
         'new_friend_check_min': (60, 3600, 60),
         'new_friend_check_max': (60, 3600, 300),
+        'chat_max_round_default': (1, 99999, 99),
+        'chat_max_round_reset_days': (0, 365, 0),
     }
     for field, (lo, hi, default) in int_range_fields.items():
         if field in merged_config:
@@ -826,13 +838,13 @@ def _coerce_dict_fields(merged_config):
     if 'keyword_dict' in merged_config:
         kd = merged_config['keyword_dict']
         if isinstance(kd, dict):
-            return
+            pass
         if isinstance(kd, str):
             try:
                 obj = json.loads(kd)
                 if isinstance(obj, dict):
                     merged_config['keyword_dict'] = obj
-                    return
+                    kd = obj
             except Exception:
                 pass
         if isinstance(kd, list):
@@ -844,9 +856,10 @@ def _coerce_dict_fields(merged_config):
                     if key:
                         out[key] = val
             merged_config['keyword_dict'] = out
-            return
+            kd = out
         # 其他情况回退空 dict
-        merged_config['keyword_dict'] = {}
+        if not isinstance(kd, dict):
+            merged_config['keyword_dict'] = {}
 
     # group_api_map: 值必须为 int 接口索引，非法值自动过滤
     if 'group_api_map' in merged_config:
@@ -881,6 +894,23 @@ def _coerce_dict_fields(merged_config):
             merged_config['chat_api_map'] = clean
         else:
             merged_config['chat_api_map'] = {}
+
+    # chat_max_round_map: 白名单模式下私聊用户专属回复次数上限，范围 1~99999
+    if 'chat_max_round_map' in merged_config:
+        cmrm = merged_config['chat_max_round_map']
+        if isinstance(cmrm, dict):
+            clean = {}
+            for k, v in cmrm.items():
+                k = str(k).strip()
+                try:
+                    vi = int(v)
+                    if k:
+                        clean[k] = max(1, min(99999, vi))
+                except (ValueError, TypeError):
+                    pass
+            merged_config['chat_max_round_map'] = clean
+        else:
+            merged_config['chat_max_round_map'] = {}
 
     # chat_prompt_map: 值为非空字符串（prompt 文件名）
     if 'chat_prompt_map' in merged_config:
@@ -1755,8 +1785,15 @@ def main():
                 "default_prompt": "默认",
                 "chat_prompt_map": {},
                 "chat_api_map": {},
+                "chat_max_round_map": {},
                 "group_prompt_map": {},
                 "api_error_reply": "在忙，我稍后回复您",
+                "api_error_reply_once": False,
+                "chat_max_round_switch": False,
+                "chat_max_round_default": 99,
+                "chat_max_round_reset_days": 0,
+                "chat_max_round_reply": "",
+                "chat_max_round_reply_once": False,
                 "chat_split_reply_switch": False,
                 "chat_split_max_chars": 100,
                 "chat_split_max_count": 4,

--- a/web_server.py
+++ b/web_server.py
@@ -10,6 +10,8 @@ from flask import Flask, render_template, request, jsonify, session, redirect, u
 import json
 import os
 import shutil
+import base64
+import tempfile
 from werkzeug.utils import secure_filename
 from werkzeug.middleware.proxy_fix import ProxyFix
 from werkzeug.security import check_password_hash, generate_password_hash
@@ -1022,6 +1024,62 @@ def _build_test_api_client(tmp_config):
         return CozeAPI(tmp_config)
     return DusAPI(tmp_config)
 
+_TINY_PNG_BASE64 = (
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII="
+)
+
+def _run_api_image_test(api, sdk):
+    """用内置极小 PNG 测试当前接口是否支持图片输入。"""
+    if sdk not in ("OpenAI SDK", "DusAPI"):
+        return {
+            'status': 'skipped',
+            'message': '当前接口类型暂不支持通用图片测试'
+        }
+    tmp_path = None
+    try:
+        with tempfile.NamedTemporaryFile(delete=False, suffix='.png') as f:
+            f.write(base64.b64decode(_TINY_PNG_BASE64))
+            tmp_path = f.name
+        reply = api.chat(
+            "请只回复 OK",
+            stream=False,
+            prompt="你是图片识别连通性测试助手。请确认你能读取图片，并只回复 OK。",
+            history=[],
+            image_path=tmp_path,
+        )
+        raw_reply = str(reply or "")
+        cleaned_reply = clean_ai_reply_text(raw_reply)
+        if not raw_reply or raw_reply == "API返回错误，请稍后再试":
+            return {
+                'status': 'error',
+                'message': '图片测试未返回有效文本，请确认模型支持视觉输入'
+            }
+        return {
+            'status': 'success',
+            'reply': cleaned_reply or '（清洗后为空）',
+            'raw_length': len(raw_reply),
+            'cleaned': cleaned_reply != raw_reply,
+        }
+    except TypeError as e:
+        return {
+            'status': 'skipped',
+            'message': f'当前接口类暂不支持图片参数：{e}'
+        }
+    except Exception as e:
+        msg = str(e)
+        if len(msg) > 500:
+            msg = msg[:500] + '...'
+        return {
+            'status': 'error',
+            'message': f'图片测试失败：{msg}'
+        }
+    finally:
+        if tmp_path and os.path.exists(tmp_path):
+            try:
+                os.remove(tmp_path)
+            except Exception:
+                pass
+
 
 @app.route('/test_api_config', methods=['POST'])
 @login_required
@@ -1053,6 +1111,7 @@ def test_api_config_route():
                 'message': '接口有响应，但未返回有效文本，请检查模型名称、接口地址或服务商兼容性'
             })
 
+        image_test = _run_api_image_test(api, tmp_config.api_sdk)
         elapsed_ms = int((time.time() - started) * 1000)
         return jsonify({
             'status': 'success',
@@ -1061,6 +1120,7 @@ def test_api_config_route():
                 'raw_length': len(raw_reply),
                 'cleaned': cleaned,
                 'elapsed_ms': elapsed_ms,
+                'image_test': image_test,
             }
         })
     except Exception as e:

--- a/web_server.py
+++ b/web_server.py
@@ -17,7 +17,7 @@ from datetime import datetime, timedelta
 import logging
 from functools import wraps
 import threading
-from wxbot_core import WXBot, version as BOT_VERSION
+from wxbot_core import CozeAPI, DifyAPI, DusAPI, OpenAIAPI, WXBot, clean_ai_reply_text, version as BOT_VERSION
 from logger import log
 import logger
 import pythoncom
@@ -667,6 +667,7 @@ def dashboard():
     config.setdefault('reply_delay_switch', True)
     config.setdefault('reply_delay_min', 1)
     config.setdefault('reply_delay_max', 5)
+    config.setdefault('clean_ai_reply_switch', True)
     config.setdefault('chat_image_recognition_switch', False)   # 私聊图片识别开关
     config.setdefault('chat_image_recognition_api',    0)        # 私聊识别接口索引
     config.setdefault('group_image_recognition_switch', False)  # 群组图片识别开关
@@ -763,6 +764,7 @@ def _coerce_bool_fields(merged_config):
         'everyday_start_stop_bot_switch',   # 新增
         'memory_switch',                    # 记忆开关
         'reply_delay_switch',               # 发送延迟开关
+        'clean_ai_reply_switch',            # AI 回复清洗开关
         'chat_image_recognition_switch',    # 私聊图片识别开关
         'group_image_recognition_switch',   # 群组图片识别开关
         'custom_forward_switch',            # 自定义转发总开关
@@ -967,6 +969,75 @@ def save_config_route():
     except Exception as e:
         log('ERROR', f'保存配置出错: {str(e)}')
         return jsonify({'status': 'error', 'message': str(e)})
+
+
+class _TempAPIConfig:
+    """用于测试单个接口配置的轻量配置对象，不读写 config.json。"""
+
+    def __init__(self, cfg):
+        self.api_sdk = str(cfg.get('sdk', '')).strip()
+        self.api_key = str(cfg.get('key', '')).strip()
+        self.base_url = str(cfg.get('url', '')).strip().rstrip('/')
+        self.model1 = str(cfg.get('model', '')).strip()
+        self.prompt = "你是接口连通性测试助手。请只回复 OK。"
+
+
+def _build_test_api_client(tmp_config):
+    sdk = tmp_config.api_sdk
+    if sdk == "OpenAI SDK":
+        return OpenAIAPI(tmp_config)
+    if sdk == "Dify":
+        return DifyAPI(tmp_config)
+    if sdk == "Coze":
+        return CozeAPI(tmp_config)
+    return DusAPI(tmp_config)
+
+
+@app.route('/test_api_config', methods=['POST'])
+@login_required
+def test_api_config_route():
+    started = time.time()
+    try:
+        data = request.get_json() or {}
+        cfg = data.get('api_config') or {}
+        if not isinstance(cfg, dict):
+            return jsonify({'status': 'error', 'message': '接口配置格式无效'})
+
+        tmp_config = _TempAPIConfig(cfg)
+        if not tmp_config.api_key:
+            return jsonify({'status': 'error', 'message': 'API Key 不能为空'})
+        if not tmp_config.base_url:
+            return jsonify({'status': 'error', 'message': 'Base URL 不能为空'})
+        if not tmp_config.model1:
+            return jsonify({'status': 'error', 'message': '模型名称不能为空'})
+
+        api = _build_test_api_client(tmp_config)
+        reply = api.chat("请只回复 OK", stream=False, prompt=tmp_config.prompt, history=[])
+        raw_reply = str(reply or "")
+        cleaned_reply = clean_ai_reply_text(raw_reply)
+        cleaned = cleaned_reply != raw_reply
+
+        if not raw_reply or raw_reply == "API返回错误，请稍后再试":
+            return jsonify({
+                'status': 'error',
+                'message': '接口有响应，但未返回有效文本，请检查模型名称、接口地址或服务商兼容性'
+            })
+
+        elapsed_ms = int((time.time() - started) * 1000)
+        return jsonify({
+            'status': 'success',
+            'data': {
+                'reply': cleaned_reply or '（清洗后为空：接口可能只返回了思考内容）',
+                'raw_length': len(raw_reply),
+                'cleaned': cleaned,
+                'elapsed_ms': elapsed_ms,
+            }
+        })
+    except Exception as e:
+        msg = str(e)
+        if len(msg) > 800:
+            msg = msg[:800] + '...'
+        return jsonify({'status': 'error', 'message': f'接口测试失败：{msg}'})
 
 # ----------------------------------------------------------
 # Prompt 文件管理路由
@@ -1674,6 +1745,7 @@ def main():
                 "reply_delay_switch": True,
                 "reply_delay_min": 1,
                 "reply_delay_max": 5,
+                "clean_ai_reply_switch": True,
                 "chat_image_recognition_switch": False,
                 "chat_image_recognition_api": 0,
                 "group_image_recognition_switch": False,

--- a/wxbot_core.py
+++ b/wxbot_core.py
@@ -19,6 +19,9 @@ import threading
 import traceback
 from datetime import datetime, timedelta
 
+THINK_BLOCK_RE = re.compile(r'<think\b[^>]*>.*?</think>', re.IGNORECASE | re.DOTALL)
+LEADING_THINK_RE = re.compile(r'^\s*<think\b[^>]*>', re.IGNORECASE)
+
 # ============================================================
 # 第三方库导入
 # ============================================================
@@ -109,6 +112,31 @@ SPLIT_PROMPT_TEMPLATE = """\
 这个问题其实很常见，主要原因是……
 【以下是你的角色设定】
 {base_prompt}"""
+
+
+def clean_ai_reply_text(text):
+    """清理模型回复中的思考标签，避免把推理过程发送给用户。"""
+    if text is None:
+        return ""
+    text = str(text)
+    cleaned = THINK_BLOCK_RE.sub("", text)
+    removed_think = cleaned != text
+
+    # 未闭合的开头 <think> 视为不安全输出：只保留空行后的正文。
+    # 不处理中间出现的未闭合示例，降低误伤普通文本的概率。
+    if LEADING_THINK_RE.search(cleaned):
+        tail_match = re.search(r'\n\s*\n', cleaned)
+        if tail_match:
+            cleaned = cleaned[tail_match.end():]
+        else:
+            cleaned = ""
+
+    lines = [line.rstrip() for line in cleaned.splitlines()]
+    cleaned = "\n".join(lines).strip()
+    if removed_think:
+        cleaned = re.sub(r'\n\s*\n+', '\n', cleaned)
+    return cleaned
+
 
 # ============================================================
 # 配置管理类
@@ -204,6 +232,7 @@ class WXBotConfig:
         self.reply_delay_switch = True  # 模拟人工操作延迟开关（默认开启）
         self.reply_delay_min    = 1     # 最小延迟秒数
         self.reply_delay_max    = 5     # 最大延迟秒数
+        self.clean_ai_reply_switch = True  # AI 回复清洗开关
 
         # 初始化时自动加载配置并同步到属性
         self.load_config()
@@ -290,6 +319,7 @@ class WXBotConfig:
                     "reply_delay_switch": True,
                     "reply_delay_min": 1,
                     "reply_delay_max": 5,
+                    "clean_ai_reply_switch": True,
                     "chat_image_recognition_switch": False,
                     "chat_image_recognition_api": 0,
                     "group_image_recognition_switch": False,
@@ -528,6 +558,7 @@ class WXBotConfig:
         self.reply_delay_switch = bool(self.config.get('reply_delay_switch', True))
         self.reply_delay_min    = max(1, int(self.config.get('reply_delay_min', 1)))
         self.reply_delay_max    = max(1, int(self.config.get('reply_delay_max', 5)))
+        self.clean_ai_reply_switch = bool(self.config.get('clean_ai_reply_switch', True))
 
         # 图片识别配置
         self.chat_image_recognition_switch  = bool(self.config.get('chat_image_recognition_switch', False))
@@ -2591,6 +2622,8 @@ class WXBot:
                 # 接口调用失败时替换为配置的固定回复
                 if reply == "API返回错误，请稍后再试":
                     reply = self.config.api_error_reply
+                else:
+                    reply = self._clean_reply_for_send(reply)
 
                 # 拆分多条回复：首条 @ 发言人，后续条不 @
                 if self.config.group_split_reply_switch:
@@ -2675,6 +2708,16 @@ class WXBot:
         """按 ||SPLIT|| 分隔符解析回复，过滤空白，截断到 max_count 条"""
         parts = [p.strip() for p in reply.split(SPLIT_SEPARATOR) if p.strip()]
         return parts[:max_count] if parts else [reply]
+
+    def _clean_reply_for_send(self, reply):
+        """按配置清洗即将发送给用户的 AI 回复。"""
+        if not self.config.clean_ai_reply_switch:
+            return reply
+        cleaned = clean_ai_reply_text(reply)
+        if cleaned:
+            return cleaned
+        log(level="WARNING", message="AI 回复清洗后为空，已使用接口失败固定回复兜底")
+        return self.config.api_error_reply
 
     def _is_custom_forward_source(self, chat_who):
         """判断某个会话是否是任意自定义转发规则的监听来源"""
@@ -2803,6 +2846,8 @@ class WXBot:
         # 接口调用失败时替换为配置的固定回复
         if reply == "API返回错误，请稍后再试":
             reply = self.config.api_error_reply
+        else:
+            reply = self._clean_reply_for_send(reply)
 
         # 拆分多条回复：仅在开关开启且回复包含分隔符时生效
         if self.config.chat_split_reply_switch:

--- a/wxbot_core.py
+++ b/wxbot_core.py
@@ -200,6 +200,7 @@ class WXBotConfig:
         self.default_prompt   = "默认"      # 全局/fallback prompt 文件名（不含 .md）
         self.chat_prompt_map  = {}          # 私聊白名单用户 -> prompt 名称
         self.chat_api_map     = {}          # 私聊白名单用户 -> API 接口索引
+        self.chat_max_round_map = {}        # 私聊白名单用户 -> 专属回复轮数上限
         self.group_prompt_map = {}          # 群组名称 -> prompt 名称
 
         # ---------- 定时消息配置 ----------
@@ -298,6 +299,7 @@ class WXBotConfig:
                     "default_prompt": "默认",
                     "chat_prompt_map": {},
                     "chat_api_map": {},
+                    "chat_max_round_map": {},
                     "group_prompt_map": {},
                     "scheduled_msg_switch": False,
                     "scheduled_msg_list": [],
@@ -325,6 +327,12 @@ class WXBotConfig:
                     "group_image_recognition_switch": False,
                     "group_image_recognition_api": 0,
                     "api_error_reply": "在忙，我稍后回复您",
+                    "api_error_reply_once": False,
+                    "chat_max_round_switch": False,
+                    "chat_max_round_default": 99,
+                    "chat_max_round_reset_days": 0,
+                    "chat_max_round_reply": "",
+                    "chat_max_round_reply_once": False,
                     "chat_split_reply_switch": False,
                     "chat_split_max_chars": 100,
                     "chat_split_max_count": 4,
@@ -574,11 +582,22 @@ class WXBotConfig:
         self.default_prompt   = self.config.get('default_prompt', '默认')
         self.chat_prompt_map  = self.config.get('chat_prompt_map', {})
         self.chat_api_map     = self.config.get('chat_api_map', {})
+        self.chat_max_round_map = self._normalize_chat_max_round_map(
+            self.config.get('chat_max_round_map', {})
+        )
         self.group_prompt_map = self.config.get('group_prompt_map', {})
         self.init_prompt_dir()
 
         # 接口调用失败时的固定回复
         self.api_error_reply = self.config.get('api_error_reply', '在忙，我稍后回复您')
+        self.api_error_reply_once = bool(self.config.get('api_error_reply_once', False))
+
+        # 单用户最大回复轮数限制配置
+        self.chat_max_round_switch = bool(self.config.get('chat_max_round_switch', False))
+        self.chat_max_round_default = self._coerce_int_range(self.config.get('chat_max_round_default', 99), 99, 1, 99999)
+        self.chat_max_round_reset_days = self._coerce_int_range(self.config.get('chat_max_round_reset_days', 0), 0, 0, 365)
+        self.chat_max_round_reply = self.config.get('chat_max_round_reply', '')
+        self.chat_max_round_reply_once = bool(self.config.get('chat_max_round_reply_once', False))
 
         # 拆分多条回复配置
         self.chat_split_reply_switch  = bool(self.config.get('chat_split_reply_switch', False))
@@ -693,6 +712,32 @@ class WXBotConfig:
     def split_long_text(text, chunk_size=2000):
         """将超长文本按指定长度切分为列表，用于分段发送"""
         return [text[i:i + chunk_size] for i in range(0, len(text), chunk_size)]
+
+    @staticmethod
+    def _normalize_chat_max_round_map(raw_map):
+        """清洗私聊白名单用户的专属回复轮数上限配置"""
+        if not isinstance(raw_map, dict):
+            return {}
+        clean = {}
+        for name, value in raw_map.items():
+            name = str(name).strip()
+            if not name:
+                continue
+            try:
+                value = int(value)
+            except Exception:
+                continue
+            clean[name] = max(1, min(99999, value))
+        return clean
+
+    @staticmethod
+    def _coerce_int_range(value, default, min_value, max_value):
+        """将配置值转为指定范围内的整数"""
+        try:
+            value = int(value)
+        except Exception:
+            value = default
+        return max(min_value, min(max_value, value))
 
     def human_delay(self):
         """模拟人工操作随机延迟。reply_delay_switch 关闭时直接跳过。"""
@@ -858,6 +903,179 @@ class MemoryManager:
                 except Exception:
                     pass
         return count
+
+
+# ============================================================
+# 回复计数器管理类
+# ============================================================
+
+class ReplyCountStore:
+    """
+    私聊回复计数器管理类。
+    负责持久化每个用户的 AI 回复次数、超限通知状态和 API 错误通知状态。
+    """
+
+    DEFAULT_DATA = {"meta": {"last_reset_date": ""}, "users": {}}
+
+    def __init__(self, file_path):
+        self.file_path = file_path
+        self._lock = threading.RLock()
+        self.data = self._load()
+
+    @classmethod
+    def _empty_data(cls):
+        return {"meta": {"last_reset_date": ""}, "users": {}}
+
+    @classmethod
+    def _normalize_user_data(cls, user_data):
+        if not isinstance(user_data, dict):
+            user_data = {}
+        try:
+            ai_count = int(user_data.get("ai_count", 0))
+        except Exception:
+            ai_count = 0
+        return {
+            "ai_count": max(0, ai_count),
+            "api_err_notified": bool(user_data.get("api_err_notified", False)),
+            "limit_notified": bool(user_data.get("limit_notified", False)),
+        }
+
+    @classmethod
+    def _normalize_data(cls, raw_data):
+        if not isinstance(raw_data, dict):
+            return cls._empty_data()
+        meta = raw_data.get("meta", {})
+        if not isinstance(meta, dict):
+            meta = {}
+        users = raw_data.get("users", {})
+        if not isinstance(users, dict):
+            users = {}
+        normalized_users = {}
+        for user, user_data in users.items():
+            user = str(user).strip()
+            if user:
+                normalized_users[user] = cls._normalize_user_data(user_data)
+        return {
+            "meta": {"last_reset_date": str(meta.get("last_reset_date", "") or "")},
+            "users": normalized_users,
+        }
+
+    def _load(self):
+        if not os.path.exists(self.file_path):
+            return self._empty_data()
+        try:
+            with open(self.file_path, 'r', encoding='utf-8') as f:
+                return self._normalize_data(json.load(f))
+        except Exception as e:
+            log(level="WARNING", message=f"加载 reply_count.json 失败: {e}")
+            return self._empty_data()
+
+    def _save_locked(self):
+        os.makedirs(os.path.dirname(self.file_path), exist_ok=True)
+        tmp_path = self.file_path + ".tmp"
+        with open(tmp_path, 'w', encoding='utf-8') as f:
+            json.dump(self.data, f, ensure_ascii=False, indent=4)
+        os.replace(tmp_path, self.file_path)
+
+    def save(self):
+        with self._lock:
+            self._save_locked()
+
+    def get_user(self, user_key):
+        user_key = str(user_key).strip()
+        with self._lock:
+            users = self.data.setdefault("users", {})
+            if user_key not in users:
+                users[user_key] = self._normalize_user_data({})
+            else:
+                users[user_key] = self._normalize_user_data(users[user_key])
+            return users[user_key]
+
+    def maybe_reset(self, reset_days, now=None):
+        try:
+            reset_days = int(reset_days)
+        except Exception:
+            reset_days = 0
+        if reset_days <= 0:
+            return False
+        now = now or datetime.now()
+        today = now.strftime("%Y-%m-%d")
+        with self._lock:
+            meta = self.data.setdefault("meta", {})
+            last = str(meta.get("last_reset_date", "") or "")
+            if not last:
+                meta["last_reset_date"] = today
+                self._save_locked()
+                return False
+            try:
+                last_dt = datetime.strptime(last, "%Y-%m-%d")
+            except Exception:
+                meta["last_reset_date"] = today
+                self._save_locked()
+                return False
+            delta = (now - last_dt).days
+            if delta >= reset_days:
+                self.data["users"] = {}
+                meta["last_reset_date"] = today
+                self._save_locked()
+                log(message=f"回复计数器已重置（周期 {reset_days} 天）")
+                return True
+        return False
+
+    def increment_ai_count(self, user_key):
+        with self._lock:
+            user_data = self.get_user(user_key)
+            user_data["ai_count"] = user_data.get("ai_count", 0) + 1
+            self._save_locked()
+            return user_data["ai_count"]
+
+    def mark_limit_notified(self, user_key):
+        with self._lock:
+            user_data = self.get_user(user_key)
+            if user_data.get("limit_notified"):
+                return False
+            user_data["limit_notified"] = True
+            self._save_locked()
+            return True
+
+    def mark_api_err_notified(self, user_key):
+        with self._lock:
+            user_data = self.get_user(user_key)
+            if user_data.get("api_err_notified"):
+                return False
+            user_data["api_err_notified"] = True
+            self._save_locked()
+            return True
+
+    def clear_user(self, user_key):
+        user_key = str(user_key).strip()
+        with self._lock:
+            users = self.data.setdefault("users", {})
+            if user_key not in users:
+                return False
+            del users[user_key]
+            self._save_locked()
+            return True
+
+    @staticmethod
+    def was_send_success(result):
+        if result is True:
+            return True
+        if result is False or result is None:
+            return False
+        if isinstance(result, dict):
+            status = str(result.get("status", "")).lower()
+            if status in ("success", "ok", "true"):
+                return True
+            if status in ("error", "fail", "failed", "false"):
+                return False
+            if result.get("code") == 0:
+                return True
+            if result.get("success") is True:
+                return True
+            if result.get("success") is False:
+                return False
+        return bool(result)
 
 
 # ============================================================
@@ -1681,6 +1899,10 @@ class WXBot:
         self.msg_replied_count   = 0            # 已回复消息数
         self.last_msg_time       = None         # 最近一条消息的时间字符串
         self.last_msg_sender     = None         # 最近一条消息的发送者
+
+        # 私聊回复轮数计数器
+        _base = os.path.dirname(sys.executable) if hasattr(sys, '_MEIPASS') else os.path.abspath(".")
+        self.reply_count_store = ReplyCountStore(os.path.join(_base, 'config', 'reply_count.json'))
 
     def _init_api(self):
         """根据配置中的 api_sdk 字段实例化对应的 AI 接口对象（默认接口）"""
@@ -2719,6 +2941,40 @@ class WXBot:
         log(level="WARNING", message="AI 回复清洗后为空，已使用接口失败固定回复兜底")
         return self.config.api_error_reply
 
+    def _get_reply_count_key(self, chat, message=None):
+        """获取回复计数器 key；当前 wxautox4 可用稳定字段有限，先集中使用 chat.who。"""
+        return str(getattr(chat, 'who', '') or '').strip()
+
+    def _get_chat_max_round(self, user_name):
+        """获取私聊用户的回复轮数上限；白名单模式优先用户专属上限。"""
+        if not self.config.AllListen_switch:
+            custom_value = self.config.chat_max_round_map.get(user_name)
+            if custom_value:
+                return custom_value
+        return self.config.chat_max_round_default
+
+    def _check_chat_max_round_limit(self, chat, user_key):
+        """检查并处理私聊回复轮数超限；返回 (是否已处理, 发送结果)。"""
+        if not self.config.chat_max_round_switch or not user_key:
+            return False, True
+        self.reply_count_store.maybe_reset(self.config.chat_max_round_reset_days)
+        user_data = self.reply_count_store.get_user(user_key)
+        max_round = self._get_chat_max_round(user_key)
+        if user_data.get("ai_count", 0) < max_round:
+            return False, True
+
+        if self.config.chat_max_round_reply_once and user_data.get("limit_notified"):
+            return True, True
+        if not self.config.chat_max_round_reply:
+            return True, True
+
+        result = chat.SendMsg(self.config.chat_max_round_reply)
+        if ReplyCountStore.was_send_success(result):
+            self.msg_replied_count += 1
+            if self.config.chat_max_round_reply_once:
+                self.reply_count_store.mark_limit_notified(user_key)
+        return True, result
+
     def _is_custom_forward_source(self, chat_who):
         """判断某个会话是否是任意自定义转发规则的监听来源"""
         for rule in self.config.custom_forward_list:
@@ -2784,6 +3040,14 @@ class WXBot:
         # log(level="DEBUG", message=f"[DEBUG] 私聊暂停标志：{self._pause_chat_reply}，来源：{chat.who}")
         if self._pause_chat_reply:
             return True
+        result = True
+        user_key = self._get_reply_count_key(chat, message)
+        limit_handled, limit_result = self._check_chat_max_round_limit(chat, user_key)
+        if limit_handled:
+            return limit_result
+
+        api_error_reply = False
+        api_error_should_mark = False
         try:
             is_keyword = False
             # 私聊关键词优先匹配
@@ -2841,11 +3105,23 @@ class WXBot:
         except Exception as e:
             print(traceback.format_exc())
             log(level="ERROR", message=str(e) + "\nAPI返回错误，请稍后再试")
-            reply = "API返回错误，请稍后再试"
+            api_error_reply = True
+            if self.config.api_error_reply_once and user_key:
+                user_data = self.reply_count_store.get_user(user_key)
+                if user_data.get("api_err_notified"):
+                    return True
+                api_error_should_mark = True
+            reply = self.config.api_error_reply
 
         # 接口调用失败时替换为配置的固定回复
         if reply == "API返回错误，请稍后再试":
+            if self.config.api_error_reply_once and user_key:
+                user_data = self.reply_count_store.get_user(user_key)
+                if user_data.get("api_err_notified"):
+                    return True
+                api_error_should_mark = True
             reply = self.config.api_error_reply
+            api_error_reply = True
         else:
             reply = self._clean_reply_for_send(reply)
 
@@ -2855,13 +3131,22 @@ class WXBot:
         else:
             parts = [reply]
 
+        send_success = False
         for part in parts:
             self.config.human_delay()   # 每条发送前都延迟（含第一条，与原逻辑等效）
             if len(part) >= 2000:
                 for segment in self.config.split_long_text(part):
                     result = chat.SendMsg(segment)
+                    send_success = send_success or ReplyCountStore.was_send_success(result)
             else:
                 result = chat.SendMsg(part)
+                send_success = send_success or ReplyCountStore.was_send_success(result)
+
+        if send_success and api_error_should_mark:
+            self.reply_count_store.mark_api_err_notified(user_key)
+
+        if send_success and self.config.chat_max_round_switch and user_key and not api_error_reply:
+            self.reply_count_store.increment_ai_count(user_key)
 
         self.msg_replied_count += 1
         return result
@@ -3027,6 +3312,22 @@ class WXBot:
                 '[/查看错误回复] 查看接口失败固定回复\n'
                 '[/设置错误回复 ***] 修改接口失败固定回复'
             )
+        elif content == "/计数器指令":
+            _round_sw = "开启" if self.config.chat_max_round_switch else "关闭"
+            _round_reset = self.config.chat_max_round_reset_days
+            _reset_desc = "不重置" if _round_reset == 0 else f"{_round_reset}天"
+            _reply_desc = self.config.chat_max_round_reply or "（空，超限后静默）"
+            result = chat.SendMsg(
+                '--- 回复计数器 ---\n'
+                f'轮数限制开关：{_round_sw}\n'
+                f'默认上限：{self.config.chat_max_round_default} 轮\n'
+                f'白名单专属上限：{len(self.config.chat_max_round_map)} 个\n'
+                f'重置周期：{_reset_desc}\n'
+                f'超限话术：{_reply_desc}\n'
+                f'超限只回复一次：{"是" if self.config.chat_max_round_reply_once else "否"}\n'
+                f'接口失败只回复一次：{"是" if self.config.api_error_reply_once else "否"}\n'
+                '[/清除计数 昵称] 清除指定用户的回复计数与通知状态'
+            )
         elif content == "/状态":
             result = self._build_status_msg(chat, message)
         elif content == "/关键词状态":
@@ -3158,6 +3459,15 @@ class WXBot:
                 result = chat.SendMsg(f"接口失败固定回复已更新：{new_err}")
             else:
                 result = chat.SendMsg("请提供回复内容，如：/设置错误回复 在忙，我稍后回复您")
+        # --- 回复计数器清零 ---
+        elif content.startswith("/清除计数"):
+            target = re.sub("/清除计数", "", content).strip()
+            if not target:
+                result = chat.SendMsg("请提供用户昵称，如：/清除计数 张三")
+            elif self.reply_count_store.clear_user(target):
+                result = chat.SendMsg(f"已清除 {target} 的回复计数与通知状态")
+            else:
+                result = chat.SendMsg(f"未找到 {target} 的计数记录（可能尚未触发过回复）")
         else:
             # 未匹配到任何指令
             # self 消息（文件传输助手场景下机器人自身回复的同步）不调用 AI，避免误触发关键词或 AI 回复
@@ -3511,6 +3821,7 @@ class WXBot:
             '/拆分回复指令\n'
             '/新好友指令\n'
             '/接口指令\n'
+            '/计数器指令\n'
             '作者:https://www.siver.top'
         )
         return chat.SendMsg(commands)
@@ -3936,6 +4247,9 @@ class WXBot:
             "reply_delay_switch":    self.config.reply_delay_switch,
             "reply_delay_min":       self.config.reply_delay_min,
             "reply_delay_max":       self.config.reply_delay_max,
+            "chat_max_round_switch": self.config.chat_max_round_switch,
+            "chat_max_round_default": self.config.chat_max_round_default,
+            "chat_max_round_reset_days": self.config.chat_max_round_reset_days,
             "pause_chat_reply":      self._pause_chat_reply,
             "pause_group_reply":     self._pause_group_reply,
         }

--- a/wxbot_core.py
+++ b/wxbot_core.py
@@ -1103,7 +1103,35 @@ class OpenAIAPI:
             }
         )
 
-    def chat(self, message, model=None, stream=False, prompt=None, history=None):
+    @staticmethod
+    def _image_to_data_url(image_path: str = "", image_url: str = "") -> str:
+        if image_path:
+            mime_type, _ = mimetypes.guess_type(image_path)
+            if mime_type not in ("image/jpeg", "image/png", "image/gif", "image/webp"):
+                mime_type = "image/jpeg"
+            with open(image_path, "rb") as f:
+                image_data = base64.standard_b64encode(f.read()).decode("utf-8")
+            return f"data:{mime_type};base64,{image_data}"
+        if image_url:
+            return image_url
+        raise ValueError("image_path 和 image_url 不能同时为空")
+
+    @classmethod
+    def _build_chat_image_block(cls, image_path: str = "", image_url: str = "") -> dict:
+        return {
+            "type": "image_url",
+            "image_url": {"url": cls._image_to_data_url(image_path, image_url)}
+        }
+
+    @classmethod
+    def _build_responses_image_block(cls, image_path: str = "", image_url: str = "") -> dict:
+        return {
+            "type": "input_image",
+            "image_url": cls._image_to_data_url(image_path, image_url)
+        }
+
+    def chat(self, message, model=None, stream=False, prompt=None, history=None,
+             image_path: str = "", image_url: str = ""):
         """
         调用 OpenAI 兼容接口获取 AI 回复。
 
@@ -1112,6 +1140,8 @@ class OpenAIAPI:
         :param stream:  是否使用流式输出
         :param prompt:  系统提示词，为 None 时使用配置中的 prompt
         :param history: 历史消息列表（MemoryManager.get_messages 返回值）
+        :param image_path: 本地图片路径，优先于 image_url
+        :param image_url:  图片 URL，image_path 为空时使用
         :return:        AI 回复的文本字符串
         """
         if model is None:
@@ -1131,7 +1161,14 @@ class OpenAIAPI:
                 else:
                     content = f"[{t}] {raw}" if t else raw
                 messages.append({"role": role, "content": content})
-        messages.append({"role": "user", "content": message})
+        if image_path or image_url:
+            user_content = [
+                {"type": "text", "text": message},
+                self._build_chat_image_block(image_path, image_url),
+            ]
+        else:
+            user_content = message
+        messages.append({"role": "user", "content": user_content})
 
         try:
             response = self.client.chat.completions.create(
@@ -1144,7 +1181,7 @@ class OpenAIAPI:
             error_type = type(e).__name__
             log(level="WARN", message=f"Chat Completions API 调用失败 [{error_type}]: {error_msg}")
             log(level="INFO", message="尝试备用方案（Responses API）")
-            return self._try_responses_api(message, model, stream, prompt)
+            return self._try_responses_api(message, model, stream, prompt, image_path, image_url)
 
         try:
             if stream:
@@ -1181,7 +1218,7 @@ class OpenAIAPI:
                     return result
                 else:
                     log(level="WARN", message=f"流式响应为空（收到 {chunk_count} 个块），尝试备用方案")
-                    return self._try_responses_api(message, model, stream, prompt)
+                    return self._try_responses_api(message, model, stream, prompt, image_path, image_url)
             else:
                 # 非流式模式：直接取 choices[0] 的消息内容
                 if response.choices and len(response.choices) > 0:
@@ -1194,16 +1231,16 @@ class OpenAIAPI:
                         return output
                     else:
                         log(level="WARN", message="非流式响应内容为空，尝试备用方案")
-                        return self._try_responses_api(message, model, stream, prompt)
+                        return self._try_responses_api(message, model, stream, prompt, image_path, image_url)
                 else:
                     log(level="WARN", message="响应中没有 choices，尝试备用方案")
-                    return self._try_responses_api(message, model, stream, prompt)
+                    return self._try_responses_api(message, model, stream, prompt, image_path, image_url)
         except Exception as e:
             error_type = type(e).__name__
             log(level="WARN", message=f"解析 API 响应出错 [{error_type}]: {str(e)}，尝试备用方案")
-            return self._try_responses_api(message, model, stream, prompt)
+            return self._try_responses_api(message, model, stream, prompt, image_path, image_url)
 
-    def _try_responses_api(self, message, model, stream, prompt):
+    def _try_responses_api(self, message, model, stream, prompt, image_path="", image_url=""):
         """
         备用方案：使用 Responses API 调用。
         当 Chat Completions API 返回非 JSON 格式时自动降级到此方案。
@@ -1214,12 +1251,22 @@ class OpenAIAPI:
                 log(level="WARN", message="备用方案不支持流式输出，将使用非流式模式")
 
             log(message=f"备用方案：使用 Responses API, model={model}")
-            # Responses API 的 input 只接受字符串，将 prompt 拼接到消息中
-            input_text = f"这是prompt，请不要把这个当做用户输入：{prompt}\n\n这是用户消息，你需要参照prompt来回复用户消息：{message}" if prompt and prompt.strip() else message
+            if image_path or image_url:
+                input_text = f"这是prompt，请不要把这个当做用户输入：{prompt}\n\n这是用户消息，你需要参照prompt来回复用户消息：{message}" if prompt and prompt.strip() else message
+                input_payload = [{
+                    "role": "user",
+                    "content": [
+                        {"type": "input_text", "text": input_text},
+                        self._build_responses_image_block(image_path, image_url),
+                    ],
+                }]
+            else:
+                # Responses API 的 input 可接受字符串，将 prompt 拼接到消息中
+                input_payload = f"这是prompt，请不要把这个当做用户输入：{prompt}\n\n这是用户消息，你需要参照prompt来回复用户消息：{message}" if prompt and prompt.strip() else message
 
             response = self.client.responses.create(
                 model=model,
-                input=input_text,
+                input=input_payload,
                 reasoning={"effort": "none"}
             )
 


### PR DESCRIPTION
本 PR 拆分为两个提交：

1. 增加接口配置可用性测试，并支持屏蔽模型返回的 <think> 思考过程。
2. 增加单个好友回复次数限制、接口失败/超限固定回复只发送一次配置，并将默认最多回复次数设为 99，最大值设为 99999。

已验证：
- python -m py_compile wxbot_core.py web_server.py
- python -m unittest tests.test_ai_reply_cleaner tests.test_reply_count_store -v